### PR TITLE
add numerical test on SAM encoder

### DIFF
--- a/float8_playground/test.py
+++ b/float8_playground/test.py
@@ -40,6 +40,8 @@ class Float8LinearUnitTest(unittest.TestCase):
         y_ref = m_ref(x)
         y_ref.sum().backward()
 
+        self.assertTrue(y_ref.shape == y_fp8.shape)
+
         y_sqnr = compute_error(y_ref, y_fp8)
         g_sqnr = compute_error(m_ref.weight.grad, m_fp8.weight.grad)
 
@@ -67,14 +69,18 @@ class Float8LinearUnitTest(unittest.TestCase):
                 f"{buffer_name} not filled")
 
     def test_linear_nobias(self):
-        x = torch.randn(2, 3)
-        m_ref = nn.Linear(3, 4, bias=False)
-        self._test_linear_impl(x, m_ref)
+        x_shapes = ((2, 3), (4, 2, 3), (5, 4, 2, 3))
+        for x_shape in x_shapes:
+            x = torch.randn(*x_shape)
+            m_ref = nn.Linear(3, 4, bias=False)
+            self._test_linear_impl(x, m_ref)
 
     def test_linear_bias(self):
-        x = torch.randn(2, 3)
-        m_ref = nn.Linear(3, 4, bias=True)
-        self._test_linear_impl(x, m_ref)
+        x_shapes = ((2, 3), (4, 2, 3), (5, 4, 2, 3))
+        for x_shape in x_shapes:
+            x = torch.randn(*x_shape)
+            m_ref = nn.Linear(3, 4, bias=True)
+            self._test_linear_impl(x, m_ref)
 
 
 if __name__ == '__main__':

--- a/float8_playground/test_sam.py
+++ b/float8_playground/test_sam.py
@@ -1,0 +1,54 @@
+# Tests SAM with real weights with float8
+# if we want finetuning later, we can use
+# https://github.com/NielsRogge/Transformers-Tutorials/blob/master/SAM/Fine_tune_SAM_(segment_anything)_on_a_custom_dataset.ipynb
+
+import copy
+import unittest
+
+import torch
+
+from transformers import SamModel
+
+from float8_linear import swap_linear_with_float8_linear
+from float8_utils import compute_error
+
+torch.manual_seed(0)
+
+class Float8SAMIntegrationTest(unittest.TestCase):
+
+    def test_encoder_fw_bw(self):
+        model = SamModel.from_pretrained("facebook/sam-vit-base")
+        # print(model)
+
+        # for now just test the encoder to simplify things
+        encoder_ref = model.vision_encoder
+        encoder_fp8 = copy.deepcopy(encoder_ref)
+        swap_linear_with_float8_linear(encoder_fp8)
+
+        # an image 
+        data = torch.randn(1, 3, 1024, 1024)
+
+        encoder_ref_out = encoder_ref(data)
+        last_hidden_ref = encoder_ref_out.last_hidden_state
+        last_hidden_ref.sum().backward()
+
+        encoder_fp8_out = encoder_fp8(data)
+        last_hidden_fp8 = encoder_fp8_out.last_hidden_state
+        last_hidden_fp8.sum().backward()
+
+        hidden_sqnr = compute_error(last_hidden_ref, last_hidden_fp8)
+        self.assertTrue(hidden_sqnr > 20.0)
+
+        ref_name_to_grad = \
+            {name: param.grad for name, param in encoder_ref.named_parameters()}
+        for name, param in encoder_fp8.named_parameters():
+            ref_grad = ref_name_to_grad[name]
+            cur_grad = param.grad
+            # For now below is for debugging only, numerical values of
+            # fp32 baseline vs fp8 for grads are not that close for a lot
+            # of the layers in this network
+            sqnr = compute_error(ref_grad, cur_grad)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Summary:

Adds a check that using `Float8Linear` on a `SAM` encoder results in reasonable spot check accuracy.

Note that grad accuracy is not tested as it is all over the place, this is probably expected but saving investigation until later. Specifically the layernorm and positional encoding grads have a large error for fp8 version vs reference.

Test Plan:

```
python float8_playground/test.py
with-proxy python float8_playground/test_sam.py
```

Reviewers:

Subscribers:

Tasks:

Tags: