### PR TITLE
switch from scale buffers to amax buffers

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -7,47 +7,59 @@ import torch
 from torch.library import Library
 
 from float8_utils import (
-    tensor_to_scale,
+    tensor_to_amax,
+    amax_to_scale,
 )
 
 
-def mm_float8(m1, s1, m2, s2, s3, dtype3):
+def mm_float8(
+    m1,  # input 1 data
+    s1,  # input 1 scale
+    m2,  # input 2 data
+    s2,  # input 2 scale
+    # s3,  # ouput scale
+    amax3,  # amax buffer of output, updated inplace in this function
+    dtype3,  # output dtype
+):
     # naive implementation: dq -> op -> q
     # TODO(future): hook up to real kernel
     m1_fp32 = m1.float() / s1
     m2_fp32 = m2.float() / s2
     m3_fp32 = torch.mm(m1_fp32, m2_fp32)
+
     # TODO(future): switch to delayed scaling
-    s3.fill_(tensor_to_scale(m3_fp32, dtype3))
+    amax3.fill_(tensor_to_amax(m3_fp32))
+    s3 = amax_to_scale(amax3, dtype3)
+
     m3_fp32_scaled = m3_fp32 * s3
     if dtype3 == torch.float8_e4m3fn:
         return m3_fp32_scaled.to(torch.float8_e4m3fn)
     else:
         return m3_fp32_scaled.to(torch.float8_e5m2)
 
-def add_float8_e5m2(m1, s1, m2, s2, s3):
-    # for now this is only implemented for e5m2 because we only care about
-    # this for adding gradients
-    # naive implementation: dq -> op -> q
-    # TODO(future): hook up to real kernel
-    # TODO(future): change these to use original precision
-    m1_float32 = m1.float() / s1
-    m2_float32 = m2.float() / s2
-    m3_float32 = m1_float32 + m2_float32
-    s3_val = tensor_to_scale(m3_float32, torch.float8_e5m2)
-    s3.fill_(s3_val)
-    return (m3_float32 * s3).to(torch.float8_e5m2)
-
 # TODO naming of these vars is weird
-def addmm_float8(inp1, inp_s1, m1, s1, m2, s2, s3, dtype3):
+def addmm_float8(
+    inp1,  # bias data
+    inp_s1,  # bias scale
+    m1,  # input 1 data
+    s1,  # input 1 scale
+    m2,  # input 2 data
+    s2,  # input 2 scale
+    # s3,  # output scale
+    amax3,  # amax buffer of output, updated inplace in this function
+    dtype3,  # output dtype
+):
     # naive implementation: dq -> op -> q
     # TODO(future): hook up to real kernel
     inp1_fp32 = inp1.float() / inp_s1
     m1_fp32 = m1.float() / s1
     m2_fp32 = m2.float() / s2
     m3_fp32 = torch.addmm(inp1_fp32, m1_fp32, m2_fp32)
+
     # TODO(future): switch to delayed scaling
-    s3.fill_(tensor_to_scale(m3_fp32, dtype3))
+    amax3.fill_(tensor_to_amax(m3_fp32))
+    s3 = amax_to_scale(amax3, dtype3)
+
     m3_fp32_scaled = m3_fp32 * s3
     if dtype3 == torch.float8_e4m3fn:
         return m3_fp32_scaled.to(torch.float8_e4m3fn)
@@ -63,14 +75,10 @@ def addmm_float8(inp1, inp_s1, m1, s1, m2, s2, s3, dtype3):
 # These are mostly placeholder and might need to be implemented in c++ as needed
 lib = Library("aten", "FRAGMENT")
 
-lib.define("mm_float8(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3, int dtype3) -> Tensor")
+lib.define("mm_float8(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, ScalarType dtype3) -> Tensor")
 lib.impl("mm_float8", mm_float8, "CPU")
 lib.impl("mm_float8", mm_float8, "CUDA")
 
-lib.define("add_float8_e5m2(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3) -> Tensor")
-lib.impl("add_float8_e5m2", add_float8_e5m2, "CPU")
-lib.impl("add_float8_e5m2", add_float8_e5m2, "CUDA")
-
-lib.define("addmm_float8(Tensor inp1, Tensor inp_s1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3, int dtype3) -> Tensor")
+lib.define("addmm_float8(Tensor inp1, Tensor inp_s1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, ScalarType dtype3) -> Tensor")
 lib.impl("addmm_float8", addmm_float8, "CPU")
 lib.impl("addmm_float8", addmm_float8, "CUDA")

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,6 +12,8 @@ import context
 from float8_utils import (
     compute_error,
     tensor_to_scale,
+    E4M3_MAX_POS,
+    E5M2_MAX_POS,
 )
 from float8_tensor import Float8Tensor
 from float8_linear import Float8Linear
@@ -67,20 +69,21 @@ class Float8LinearUnitTest(unittest.TestCase):
 
         # verify all of the scales got updated
         buffer_names = [
-            'fp8_s_in',
-            'fp8_s_weight',
-            'fp8_s_out',
-            'fp8_s_dL_dX',
-            'fp8_s_dL_dW',
-            'fp8_s_dL_dY',
+            'float8_amax_in',
+            'float8_amax_weight',
+            'float8_amax_out',
+            'float8_amax_dL_dX',
+            'float8_amax_dL_dW',
+            'float8_amax_dL_dY',
         ]
         if m_ref.bias is not None:
-            buffer_names.append('fp8_s_bias')
+            buffer_names.append('float8_amax_bias')
         for buffer_name in buffer_names:
             buffer_value = getattr(m_fp8, buffer_name)
-            self.assertTrue(
-                torch.ne(buffer_value, torch.tensor(1.0)),
-                f"{buffer_name} not filled")
+            for init_val in (E4M3_MAX_POS, E5M2_MAX_POS):
+                self.assertTrue(
+                    torch.ne(buffer_value, torch.tensor(init_val)),
+                    f"{buffer_name} not filled, current value {buffer_value}")
 
     def test_linear_nobias(self):
         x_shapes = ((2, 3), (4, 2, 3), (5, 4, 2, 3))


### PR DESCRIPTION
Summary:

Before: scale buffers were stored, amax calculation was hidden
After: amax buffers are stored, scale calculation is stateless

This is a refactor to make it easier to enabled delayed scaling. No functionality change in this PR, just refactor.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: