### PR TITLE
switch from just-in-time scaling to delayed scaling

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -34,25 +34,46 @@ class float8_linear(torch.autograd.Function):
         float8_amax_dL_dX,
         float8_amax_dL_dW,
         float8_amax_dL_dY,
+        fw_amax_initialized,
+        bw_amax_initialized,
     ):
         ctx.save_for_backward(
-            x_fp8, w_fp8, b_fp8, float8_amax_dL_dX, float8_amax_dL_dW, float8_amax_dL_dY)
+            x_fp8, w_fp8, b_fp8, float8_amax_dL_dX, float8_amax_dL_dW, float8_amax_dL_dY,
+            bw_amax_initialized)
         orig_shape = x_fp8._data.shape
         x_fp8_data_reshaped = x_fp8._data.reshape(-1, orig_shape[-1])
+        is_fw_amax_initialized = torch.any(fw_amax_initialized)
 
         if b_fp8 is not None:
+            if not is_fw_amax_initialized:
+                # calculate reference amax of output
+                with torch.no_grad():
+                    ref_result = torch.addmm(
+                        b_fp8.to_original_precision(), 
+                        x_fp8.to_original_precision().reshape(-1, orig_shape[-1]),
+                        w_fp8.to_original_precision().t())
+                    float8_amax_out.fill_(tensor_to_amax(ref_result))
+
+            y_scale = amax_to_scale(float8_amax_out, torch.float8_e4m3fn)
             res_bits = torch.ops.aten.addmm_float8(
                 b_fp8._data, b_fp8._scale,
                 x_fp8_data_reshaped, x_fp8._scale,
                 w_fp8._data.t(), w_fp8._scale,
-                float8_amax_out, torch.float8_e4m3fn)
+                float8_amax_out, y_scale, torch.float8_e4m3fn)
         else:
+            if not is_fw_amax_initialized:
+                # calculate reference amax of output
+                with torch.no_grad():
+                    ref_result = torch.mm(
+                        x_fp8.to_original_precision().reshape(-1, orig_shape[-1]),
+                        w_fp8.to_original_precision().t())
+                    float8_amax_out.fill_(tensor_to_amax(ref_result))
+
+            y_scale = amax_to_scale(float8_amax_out, torch.float8_e4m3fn)
             res_bits = torch.ops.aten.mm_float8(
                 x_fp8_data_reshaped, x_fp8._scale,
                 w_fp8._data.t(), w_fp8._scale,
-                float8_amax_out, torch.float8_e4m3fn)
-        # y_scale has to be calculated after mm_float8 to get the updated amax
-        y_scale = amax_to_scale(float8_amax_out, torch.float8_e4m3fn)
+                float8_amax_out, y_scale, torch.float8_e4m3fn)
         res_bits = res_bits.reshape(*orig_shape[:-1], res_bits.shape[-1])
 
         res = Float8Tensor(res_bits, y_scale, x_fp8._orig_dtype)
@@ -61,13 +82,18 @@ class float8_linear(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, go):
-        x_fp8, w_fp8, b_fp8, float8_amax_dL_dX, float8_amax_dL_dW, float8_amax_dL_dY = \
-            ctx.saved_tensors
+        x_fp8, w_fp8, b_fp8, float8_amax_dL_dX, float8_amax_dL_dW, \
+            float8_amax_dL_dY, bw_amax_initialized = \
+                ctx.saved_tensors
+                
+        is_bw_amax_initialized = torch.any(bw_amax_initialized)
 
         if not isinstance(go, Float8Tensor):
-            # TODO(future): switch to delayed scaling
-            float8_amax_dL_dY.fill_(tensor_to_amax(go))
+            # TODO(future): switch to windowed delayed scaling
+            if not is_bw_amax_initialized:
+                float8_amax_dL_dY.fill_(tensor_to_amax(go))
             dL_dY_scale = amax_to_scale(float8_amax_dL_dY, torch.float8_e5m2)
+            float8_amax_dL_dY.fill_(tensor_to_amax(go))
             go_fp8 = Float8Tensor(
                 (go * dL_dY_scale).to(torch.float8_e5m2),
                 dL_dY_scale, go.dtype)
@@ -77,31 +103,48 @@ class float8_linear(torch.autograd.Function):
         go_fp8_orig_shape = go_fp8._data.shape
         go_fp8_data_reshaped = go_fp8._data.reshape(-1, go_fp8_orig_shape[-1])
 
+        if not is_bw_amax_initialized:
+            # calculate reference amax of output
+            with torch.no_grad():
+                dL_dX_ref = torch.mm(
+                    go_fp8.to_original_precision().reshape(-1, go_fp8_orig_shape[-1]),
+                    w_fp8.to_original_precision())
+                float8_amax_dL_dX.fill_(tensor_to_amax(dL_dX_ref))
+
+        dL_dX_scale = amax_to_scale(float8_amax_dL_dX, torch.float8_e5m2)
         dL_dX_bits = torch.ops.aten.mm_float8(
             go_fp8_data_reshaped, go_fp8._scale,
             w_fp8._data, w_fp8._scale,
-            float8_amax_dL_dX, torch.float8_e5m2)
-        # dL_dX_scale has to be calculated after mm_float8 to get the updated amax
-        dL_dX_scale = amax_to_scale(float8_amax_dL_dX, torch.float8_e5m2)
+            float8_amax_dL_dX, dL_dX_scale, torch.float8_e5m2)
         dL_dX_bits = dL_dX_bits.reshape(*go_fp8_orig_shape[:-1], dL_dX_bits.shape[-1])
         dL_dX_fp8 = Float8Tensor(dL_dX_bits, dL_dX_scale, go_fp8._orig_dtype)
 
         x_fp8_orig_shape = x_fp8._data.shape
         x_fp8_data_reshaped = x_fp8._data.reshape(-1, x_fp8_orig_shape[-1])
 
+        if not is_bw_amax_initialized:
+            # calculate reference amax of output
+            with torch.no_grad():
+                dL_dW_ref = torch.mm(
+                    x_fp8.to_original_precision().reshape(-1, x_fp8_orig_shape[-1]).t(),
+                    go_fp8.to_original_precision().reshape(-1, go_fp8_orig_shape[-1])).t()
+                float8_amax_dL_dW.fill_(tensor_to_amax(dL_dW_ref))
+
+        dL_dW_scale = amax_to_scale(float8_amax_dL_dW, torch.float8_e5m2)
         dL_dW_bits = torch.ops.aten.mm_float8(
             x_fp8_data_reshaped.t(), x_fp8._scale,
             go_fp8_data_reshaped, go_fp8._scale,
-            float8_amax_dL_dW, torch.float8_e5m2).t()
-        # dL_dW_scale has to be calculated after mm_float8 to get the updated amax
-        dL_dW_scale = amax_to_scale(float8_amax_dL_dW, torch.float8_e5m2)
+            float8_amax_dL_dW, dL_dW_scale, torch.float8_e5m2).t()
         dL_dW_fp8 = Float8Tensor(dL_dW_bits, dL_dW_scale, go_fp8._orig_dtype)
+
+        if not is_bw_amax_initialized:
+            bw_amax_initialized.fill_(1)
 
         # scale update would also happen here, for now no-op
         if b_fp8 is not None:
-            return dL_dX_fp8, dL_dW_fp8, go_fp8, None, None, None, None
+            return dL_dX_fp8, dL_dW_fp8, go_fp8, None, None, None, None, None, None
         else:
-            return dL_dX_fp8, dL_dW_fp8, None, None, None, None, None
+            return dL_dX_fp8, dL_dW_fp8, None, None, None, None, None, None, None
 
 
 class Float8Linear(torch.nn.Linear):
@@ -123,8 +166,11 @@ class Float8Linear(torch.nn.Linear):
         self.register_buffer('float8_amax_dL_dX', torch.tensor(E5M2_MAX_POS))
         self.register_buffer('float8_amax_dL_dW', torch.tensor(E5M2_MAX_POS))
         self.register_buffer('float8_amax_dL_dY', torch.tensor(E5M2_MAX_POS))
+        self.register_buffer('fw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
+        self.register_buffer('bw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
 
     def forward(self, x):
+        is_fw_amax_initialized = torch.any(self.fw_amax_initialized)
         if not isinstance(x, Float8Tensor):
             # Duplicate the autocast logic for F.linear, so that the output
             # of our module has the right original precision
@@ -133,26 +179,40 @@ class Float8Linear(torch.nn.Linear):
                 # if we need CPU support in the future, we can add it
                 x = x.to(torch.get_autocast_gpu_dtype())
 
-            # TODO(future): switch to delayed scaling
-            self.float8_amax_in.fill_(tensor_to_amax(x))
+            # TODO(future): switch to windowed delayed scaling
+            if not is_fw_amax_initialized:
+                self.float8_amax_in.fill_(tensor_to_amax(x))
             x_scale = amax_to_scale(self.float8_amax_in, torch.float8_e4m3fn)
+            self.float8_amax_in.fill_(tensor_to_amax(x))
+
             x_fp8 = Float8Tensor.to_float8(x, x_scale, torch.float8_e4m3fn)
         else:
             x_fp8 = x
 
-        # TODO(future): switch to delayed scaling
-        self.float8_amax_weight.fill_(tensor_to_amax(self.weight))
+        # TODO(future): switch to windowed delayed scaling
+        if not is_fw_amax_initialized:
+            self.float8_amax_weight.fill_(tensor_to_amax(self.weight))
         w_scale = amax_to_scale(self.float8_amax_weight, torch.float8_e4m3fn)
+        self.float8_amax_weight.fill_(tensor_to_amax(self.weight))
+
         w_fp8 = Float8Tensor.to_float8(self.weight, w_scale, torch.float8_e4m3fn)
         maybe_b_fp8 = None
         if self.bias is not None:
-            self.float8_amax_bias.fill_(tensor_to_amax(self.bias))
+            # TODO(future): switch to windowed delayed scaling
+            if not is_fw_amax_initialized:
+                self.float8_amax_bias.fill_(tensor_to_amax(self.bias))
             b_scale = amax_to_scale(self.float8_amax_bias, torch.float8_e4m3fn)
+            self.float8_amax_bias.fill_(tensor_to_amax(self.bias))
+
             maybe_b_fp8 = Float8Tensor.to_float8(self.bias, b_scale, torch.float8_e4m3fn)
 
         y_fp8 = float8_linear.apply(
             x_fp8, w_fp8, maybe_b_fp8, self.float8_amax_out, self.float8_amax_dL_dX,
-            self.float8_amax_dL_dW, self.float8_amax_dL_dY)
+            self.float8_amax_dL_dW, self.float8_amax_dL_dY, self.fw_amax_initialized,
+            self.bw_amax_initialized)
+
+        if not is_fw_amax_initialized:
+            self.fw_amax_initialized.fill_(1)
 
         # For now, hardcode returning Float8Tensor (propagate as much as we can).
         # This can be changed to return a different dtype, if needed.

--- a/tests/test.py
+++ b/tests/test.py
@@ -67,7 +67,7 @@ class Float8LinearUnitTest(unittest.TestCase):
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-        # verify all of the scales got updated
+        # verify all of the amax buffers got updated
         buffer_names = [
             'float8_amax_in',
             'float8_amax_weight',
@@ -84,6 +84,10 @@ class Float8LinearUnitTest(unittest.TestCase):
                 self.assertTrue(
                     torch.ne(buffer_value, torch.tensor(init_val)),
                     f"{buffer_name} not filled, current value {buffer_value}")
+
+        # verify initialization buffers got updated
+        self.assertTrue(m_fp8.fw_amax_initialized[0] == 1)
+        self.assertTrue(m_fp8.bw_amax_initialized[0] == 1)
 
     def test_linear_nobias(self):
         x_shapes = ((2, 3), (4, 2, 3), (5, 4, 2, 3))


### PR DESCRIPTION
Summary:

Before: all scaling was done just-in-time
After:
1. scaling is done in a delayed fashion with a history of 1
2. there is special logic to populate initial amaxes (TE doesn't have this)

A future PR will add windowed calculation

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: