### PR TITLE
make Float8Tensor reshape'able and t'able

### DIFF
--- a/float8_playground/float8_tensor.py
+++ b/float8_playground/float8_tensor.py
@@ -88,6 +88,19 @@ class Float8Tensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs=None):
+        if func is aten.view.default:
+            orig_tensor, view_args = args
+            new_tensor = Float8Tensor(
+                orig_tensor._data.view(*view_args), orig_tensor._scale, 
+                orig_tensor._orig_dtype)
+            return new_tensor
+        elif func is aten.t.default:
+            orig_tensor, = args
+            new_tensor = Float8Tensor(
+                orig_tensor._data.t(), orig_tensor._scale,
+                orig_tensor._orig_dtype)
+            return new_tensor
+
         # for all ops that get here, fall back to original precision
         def unwrap(t):
             if isinstance(t, Float8Tensor):

--- a/tests/test.py
+++ b/tests/test.py
@@ -45,6 +45,25 @@ class Float8TensorUnitTest(unittest.TestCase):
             x3_hp = x2_lp.to_original_precision()
             self.assertTrue(x3_hp.dtype == hp_dtype)
 
+    def test_reshape(self):
+        x1_fp32 = torch.randn(4, 4, device='cuda')
+        x1_s = tensor_to_scale(x1_fp32, torch.float8_e4m3fn)
+        x1_fp8 = Float8Tensor.to_float8(x1_fp32, x1_s, torch.float8_e4m3fn)
+        new_shape = (2, -1)
+        x2_fp32 = x1_fp32.reshape(*new_shape)
+        x2_fp8 = x1_fp8.reshape(*new_shape)
+        self.assertTrue(x2_fp8.shape == x2_fp32.shape)
+        self.assertTrue(type(x2_fp8) == Float8Tensor)
+
+    def test_transpose(self):
+        x1_fp32 = torch.randn(4, 4, device='cuda')
+        x1_s = tensor_to_scale(x1_fp32, torch.float8_e4m3fn)
+        x1_fp8 = Float8Tensor.to_float8(x1_fp32, x1_s, torch.float8_e4m3fn)
+        x2_fp32 = x1_fp32.t()
+        x2_fp8 = x1_fp8.t()
+        self.assertTrue(x2_fp8.shape == x2_fp32.shape)
+        self.assertTrue(type(x2_fp8) == Float8Tensor)
+
 
 class Float8LinearUnitTest(unittest.TestCase):
     def _test_linear_impl(self, x, m_ref):


### PR DESCRIPTION
Summary:

this simplifies some of the code in `Float8Linear`, which is nice for keeping things readable

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: