### PR TITLE
add python api to wrap aten api

### DIFF
--- a/float8_playground/float8_python_api.py
+++ b/float8_playground/float8_python_api.py
@@ -1,0 +1,34 @@
+"""
+This file defines the Python functions for float8 which expect inputs
+of class `Float8Tensor`. This is a thin wrapper on top of the aten API
+to simplify the product code.
+"""
+
+import torch
+import float8_aten_api
+
+def mm_float8(
+    x1,  # input 1
+    x2,  # input 2
+    amax3,  # output amax, updated inplace in this function
+    s3,  # output scale, precomputed
+    dtype3,  # output dtype
+):
+    return torch.ops.aten.mm_float8(
+        x1._data, x1._scale,
+        x2._data, x2._scale,
+        amax3, s3, dtype3)
+
+def addmm_float8(
+    inp1,  # addition term
+    x1,  # first mm term
+    x2,  # second mm term
+    amax3,  # output aax, updated inplace in this function
+    s3,  # output scale, precomputed
+    dtype3,  # output dtype
+):
+    return torch.ops.aten.addmm_float8(
+        inp1._data, inp1._scale,
+        x1._data, x1._scale,
+        x2._data, x2._scale,
+        amax3, s3, dtype3)


### PR DESCRIPTION
Summary:

Adds a convenience python api to wrap the aten float8 api.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: