### PR TITLE
remove fp8 bias

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -34,8 +34,7 @@ def mm_float8(
 
 # TODO naming of these vars is weird
 def addmm_float8(
-    inp1,  # bias data
-    inp_s1,  # bias scale
+    inp1,  # bias (in fp32/fp16/bf16, no fp8 support)
     m1,  # input 1 data
     s1,  # input 1 scale
     m2,  # input 2 data
@@ -46,10 +45,9 @@ def addmm_float8(
 ):
     # naive implementation: dq -> op -> q
     # TODO(future): hook up to real kernel
-    inp1_fp32 = inp1.float() / inp_s1
     m1_fp32 = m1.float() / s1
     m2_fp32 = m2.float() / s2
-    m3_fp32 = torch.addmm(inp1_fp32, m1_fp32, m2_fp32)
+    m3_fp32 = torch.addmm(inp1, m1_fp32, m2_fp32)
 
     # TODO(future): switch to delayed scaling
     amax3.fill_(tensor_to_amax(m3_fp32))
@@ -70,6 +68,6 @@ lib.define("mm_float8(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, 
 lib.impl("mm_float8", mm_float8, "CPU")
 lib.impl("mm_float8", mm_float8, "CUDA")
 
-lib.define("addmm_float8(Tensor inp1, Tensor inp_s1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, Tensor s3, ScalarType dtype3) -> Tensor")
+lib.define("addmm_float8(Tensor inp1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, Tensor s3, ScalarType dtype3) -> Tensor")
 lib.impl("addmm_float8", addmm_float8, "CPU")
 lib.impl("addmm_float8", addmm_float8, "CUDA")

--- a/float8_playground/float8_python_api.py
+++ b/float8_playground/float8_python_api.py
@@ -20,7 +20,7 @@ def mm_float8(
         amax3, s3, dtype3)
 
 def addmm_float8(
-    inp1,  # addition term
+    inp1,  # addition term (in fp32/fp16/bf16, no fp8 support)
     x1,  # first mm term
     x2,  # second mm term
     amax3,  # output aax, updated inplace in this function
@@ -28,7 +28,7 @@ def addmm_float8(
     dtype3,  # output dtype
 ):
     return torch.ops.aten.addmm_float8(
-        inp1._data, inp1._scale,
+        inp1,
         x1._data, x1._scale,
         x2._data, x2._scale,
         amax3, s3, dtype3)

--- a/tests/test.py
+++ b/tests/test.py
@@ -95,8 +95,6 @@ class Float8LinearUnitTest(unittest.TestCase):
             'fp8_amax_dL_dW',
             'fp8_amax_dL_dY',
         ]
-        if m_ref.bias is not None:
-            buffer_names.append('fp8_amax_b')
         for buffer_name in buffer_names:
             buffer_value = getattr(m_fp8, buffer_name)
             for init_val in (E4M3_MAX_POS, E5M2_MAX_POS):


### PR DESCRIPTION
Summary:

Bias in fp8 is not supported according to
https://docs.nvidia.com/cuda/cublas/#id99 , remove it from this codebase to simplify

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: