### PR TITLE
basic version of delayed scaling

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -9,6 +9,14 @@ owners to implement their own UEX.
 
 import torch
 
+from float8_linear_utils import (
+    _maybe_initialize_amaxes_for_float8_cast,
+    _maybe_initialize_amaxes_for_mm,
+    _maybe_initialize_amaxes_for_addmm,
+    _update_history_with_new_amax,
+    _update_amaxes_for_float8_cast,
+)
+
 from float8_python_api import (
     mm_float8,
     addmm_float8,
@@ -34,50 +42,55 @@ class float8_linear(torch.autograd.Function):
         w_fp8,
         b,
         fp8_amax_y,
+        fp8_amax_history_y,
         fp8_amax_dL_dX,
+        fp8_amax_history_dL_dX,
         fp8_amax_dL_dW,
+        fp8_amax_history_dL_dW,
         fw_amax_initialized,
         bw_amax_initialized,
     ):
         ctx.save_for_backward(
-            x_fp8, w_fp8, b, fp8_amax_dL_dX, fp8_amax_dL_dW,
+            x_fp8, w_fp8, b, 
+            fp8_amax_dL_dX, fp8_amax_history_dL_dX,
+            fp8_amax_dL_dW, fp8_amax_history_dL_dW,
             bw_amax_initialized)
         orig_shape = x_fp8._data.shape
         x_fp8_reshaped = x_fp8.reshape(-1, orig_shape[-1])
         is_fw_amax_initialized = torch.any(fw_amax_initialized)
 
         if b is not None:
-            if not is_fw_amax_initialized:
-                # calculate reference amax of output
-                with torch.no_grad():
-                    ref_result = torch.addmm(b, x_fp8_reshaped, w_fp8.t())
-                    fp8_amax_y.fill_(tensor_to_amax(ref_result))
+            _maybe_initialize_amaxes_for_addmm(
+                b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
+                is_fw_amax_initialized)
 
+            # TODO(next): calculate scale based on history here
             y_scale = amax_to_scale(fp8_amax_y, torch.float8_e4m3fn)
             res_bits = addmm_float8(
                 b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale, 
                 torch.float8_e4m3fn)
-        else:
-            if not is_fw_amax_initialized:
-                # calculate reference amax of output
-                with torch.no_grad():
-                    ref_result = torch.mm(x_fp8_reshaped, w_fp8.t())
-                    fp8_amax_y.fill_(tensor_to_amax(ref_result))
+            _update_history_with_new_amax(fp8_amax_y, fp8_amax_history_y)
 
+        else:
+            _maybe_initialize_amaxes_for_mm(
+                x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
+                is_fw_amax_initialized)
+
+            # TODO(next): calculate scale based on history here
             y_scale = amax_to_scale(fp8_amax_y, torch.float8_e4m3fn)
             res_bits = mm_float8(
                 x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale, 
                 torch.float8_e4m3fn)
+            _update_history_with_new_amax(fp8_amax_y, fp8_amax_history_y)
         res_bits = res_bits.reshape(*orig_shape[:-1], res_bits.shape[-1])
 
         res = Float8Tensor(res_bits, y_scale, x_fp8._orig_dtype)
-        # scale update would also happen here, for now no-op
         return res
 
     @staticmethod
     def backward(ctx, go_fp8):
-        x_fp8, w_fp8, b_fp8, fp8_amax_dL_dX, fp8_amax_dL_dW, \
-            bw_amax_initialized = \
+        x_fp8, w_fp8, b_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, \
+            fp8_amax_dL_dW, fp8_amax_history_dL_dW, bw_amax_initialized = \
                 ctx.saved_tensors
                 
         is_bw_amax_initialized = torch.any(bw_amax_initialized)
@@ -85,66 +98,72 @@ class float8_linear(torch.autograd.Function):
         go_fp8_orig_shape = go_fp8._data.shape
         go_fp8_reshaped = go_fp8.reshape(-1, go_fp8_orig_shape[-1])
 
-        if not is_bw_amax_initialized:
-            # calculate reference amax of output
-            with torch.no_grad():
-                dL_dX_ref = torch.mm(go_fp8_reshaped, w_fp8)
-                fp8_amax_dL_dX.fill_(tensor_to_amax(dL_dX_ref))
+        #
+        # calculate dL/dX, update relevant buffers along the way
+        #
+        _maybe_initialize_amaxes_for_mm(
+            go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, 
+            is_bw_amax_initialized)
 
+        # TODO(next): calculate scale based on history here
         dL_dX_scale = amax_to_scale(fp8_amax_dL_dX, torch.float8_e5m2)
         dL_dX_bits = mm_float8(
             go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, dL_dX_scale, torch.float8_e5m2)
+        _update_history_with_new_amax(fp8_amax_dL_dX, fp8_amax_history_dL_dX)
         dL_dX_bits = dL_dX_bits.reshape(*go_fp8_orig_shape[:-1], dL_dX_bits.shape[-1])
         dL_dX_fp8 = Float8Tensor(dL_dX_bits, dL_dX_scale, go_fp8._orig_dtype)
 
         x_fp8_orig_shape = x_fp8._data.shape
         x_fp8_reshaped = x_fp8.reshape(-1, x_fp8_orig_shape[-1])
 
-        if not is_bw_amax_initialized:
-            # calculate reference amax of output
-            with torch.no_grad():
-                dL_dW_ref = torch.mm(x_fp8_reshaped.t(), go_fp8_reshaped).t()
-                fp8_amax_dL_dW.fill_(tensor_to_amax(dL_dW_ref))
+        #
+        # calculate dL/dW, update relevant buffers along the way
+        #
+        _maybe_initialize_amaxes_for_mm(
+            x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, fp8_amax_history_dL_dW,
+            is_bw_amax_initialized)
 
+        # TODO(next): calculate scale based on history here
         dL_dW_scale = amax_to_scale(fp8_amax_dL_dW, torch.float8_e5m2)
         dL_dW_bits = mm_float8(
             x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, 
             dL_dW_scale, torch.float8_e5m2).t()
+        _update_history_with_new_amax(fp8_amax_dL_dW, fp8_amax_history_dL_dW)
         dL_dW_fp8 = Float8Tensor(dL_dW_bits, dL_dW_scale, go_fp8._orig_dtype)
 
         if not is_bw_amax_initialized:
             bw_amax_initialized.fill_(1)
 
-        # scale update would also happen here, for now no-op
+        empty_grads = None, None, None, None, None, None, None, None, None
         if b_fp8 is not None:
-            return dL_dX_fp8, dL_dW_fp8, go_fp8, None, None, None, None, None
+            return dL_dX_fp8, dL_dW_fp8, go_fp8, *empty_grads
         else:
-            return dL_dX_fp8, dL_dW_fp8, None, None, None, None, None, None
+            return dL_dX_fp8, dL_dW_fp8, *empty_grads
 
 class _NoOpFwToFloat8E5M2Bw(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, fp8_amax_dL_dY, bw_amax_initialized):
-        ctx.save_for_backward(fp8_amax_dL_dY, bw_amax_initialized)
+    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized):
+        ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized)
         return x
 
     @staticmethod
     def backward(ctx, go):
-        fp8_amax_dL_dY, bw_amax_initialized = ctx.saved_tensors
+        fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized = ctx.saved_tensors
         is_bw_amax_initialized = torch.any(bw_amax_initialized)
         if not isinstance(go, Float8Tensor):
             # TODO(future): switch to windowed delayed scaling
             with torch.no_grad():
-                if not is_bw_amax_initialized:
-                    fp8_amax_dL_dY.fill_(tensor_to_amax(go))
+                _maybe_initialize_amaxes_for_float8_cast(
+                    go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_bw_amax_initialized)
+                # TODO(next): calculate scale based on history here
                 dL_dY_scale = amax_to_scale(fp8_amax_dL_dY, torch.float8_e5m2)
-                fp8_amax_dL_dY.fill_(tensor_to_amax(go))
-            go_fp8 = Float8Tensor(
-                (go * dL_dY_scale).to(torch.float8_e5m2),
-                dL_dY_scale, go.dtype)
+                go_fp8 = Float8Tensor.to_float8(
+                    go, dL_dY_scale, torch.float8_e5m2)
+                _update_amaxes_for_float8_cast(
+                    go, fp8_amax_dL_dY, fp8_amax_history_dL_dY)
         else:
             go_fp8 = go
-        return go_fp8, None, None
-
+        return go_fp8, None, None, None
 
 class Float8Linear(torch.nn.Linear):
     """
@@ -153,17 +172,21 @@ class Float8Linear(torch.nn.Linear):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # While this module currently implements just-in-time scaling,
-        # the scales are stored in buffers as a placeholder for delayed
-        # scaling such as the mechanism described in
-        # https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html#Mixed-precision-training-with-FP8,
-        # or PTQ calibration.
+        # TODO(future): make history_len configurable, for now it's a default
+        # set for easy debugging
+        history_len = 4
         self.register_buffer('fp8_amax_x', torch.tensor(E4M3_MAX_POS))
+        self.register_buffer('fp8_amax_history_x', torch.zeros(history_len))
         self.register_buffer('fp8_amax_w', torch.tensor(E4M3_MAX_POS))
+        self.register_buffer('fp8_amax_history_w', torch.zeros(history_len))
         self.register_buffer('fp8_amax_y', torch.tensor(E4M3_MAX_POS))
+        self.register_buffer('fp8_amax_history_y', torch.zeros(history_len))
         self.register_buffer('fp8_amax_dL_dX', torch.tensor(E5M2_MAX_POS))
+        self.register_buffer('fp8_amax_history_dL_dX', torch.zeros(history_len))
         self.register_buffer('fp8_amax_dL_dW', torch.tensor(E5M2_MAX_POS))
+        self.register_buffer('fp8_amax_history_dL_dW', torch.zeros(history_len))
         self.register_buffer('fp8_amax_dL_dY', torch.tensor(E5M2_MAX_POS))
+        self.register_buffer('fp8_amax_history_dL_dY', torch.zeros(history_len))
         self.register_buffer('fw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
         self.register_buffer('bw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
 
@@ -178,33 +201,38 @@ class Float8Linear(torch.nn.Linear):
                 x = x.to(torch.get_autocast_gpu_dtype())
 
             # TODO(future): switch to windowed delayed scaling
-            if not is_fw_amax_initialized:
-                self.fp8_amax_x.fill_(tensor_to_amax(x))
+            _maybe_initialize_amaxes_for_float8_cast(
+                x, self.fp8_amax_x, self.fp8_amax_history_x, is_fw_amax_initialized)
+            # TODO(next): calculate state from history
             x_scale = amax_to_scale(self.fp8_amax_x, torch.float8_e4m3fn)
-            self.fp8_amax_x.fill_(tensor_to_amax(x))
-
             x_fp8 = Float8Tensor.to_float8(x, x_scale, torch.float8_e4m3fn)
+            _update_amaxes_for_float8_cast(
+                x, self.fp8_amax_x, self.fp8_amax_history_x)
         else:
             x_fp8 = x
 
         # TODO(future): switch to windowed delayed scaling
-        if not is_fw_amax_initialized:
-            self.fp8_amax_w.fill_(tensor_to_amax(self.weight))
+        _maybe_initialize_amaxes_for_float8_cast(
+            self.weight, self.fp8_amax_w, self.fp8_amax_history_w, is_fw_amax_initialized)
+        # TODO(next): calculate state from history
         w_scale = amax_to_scale(self.fp8_amax_w, torch.float8_e4m3fn)
-        self.fp8_amax_w.fill_(tensor_to_amax(self.weight))
-
         w_fp8 = Float8Tensor.to_float8(self.weight, w_scale, torch.float8_e4m3fn)
+        _update_amaxes_for_float8_cast(
+            self.weight, self.fp8_amax_w, self.fp8_amax_history_w)
 
         y_fp8 = float8_linear.apply(
-            x_fp8, w_fp8, self.bias, self.fp8_amax_y, self.fp8_amax_dL_dX,
-            self.fp8_amax_dL_dW, self.fw_amax_initialized, self.bw_amax_initialized)
+            x_fp8, w_fp8, self.bias, 
+            self.fp8_amax_y, self.fp8_amax_history_y, 
+            self.fp8_amax_dL_dX, self.fp8_amax_history_dL_dX,
+            self.fp8_amax_dL_dW, self.fp8_amax_history_dL_dW,
+            self.fw_amax_initialized, self.bw_amax_initialized)
 
         if not is_fw_amax_initialized:
             self.fw_amax_initialized.fill_(1)
 
         # Set up cast to fp8 in bw
         y_fp8 = _NoOpFwToFloat8E5M2Bw.apply(
-            y_fp8, self.fp8_amax_dL_dY, self.bw_amax_initialized)
+            y_fp8, self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY, self.bw_amax_initialized)
 
         # For now, hardcode returning Float8Tensor (propagate as much as we can).
         # This can be changed to return a different dtype, if needed.

--- a/tests/test.py
+++ b/tests/test.py
@@ -87,7 +87,7 @@ class Float8LinearUnitTest(unittest.TestCase):
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
         # verify all of the amax buffers got updated
-        buffer_names = [
+        amax_buffer_names = [
             'fp8_amax_x',
             'fp8_amax_w',
             'fp8_amax_y',
@@ -95,12 +95,25 @@ class Float8LinearUnitTest(unittest.TestCase):
             'fp8_amax_dL_dW',
             'fp8_amax_dL_dY',
         ]
-        for buffer_name in buffer_names:
+        for buffer_name in amax_buffer_names:
             buffer_value = getattr(m_fp8, buffer_name)
             for init_val in (E4M3_MAX_POS, E5M2_MAX_POS):
                 self.assertTrue(
                     torch.ne(buffer_value, torch.tensor(init_val)),
                     f"{buffer_name} not filled, current value {buffer_value}")
+
+        # verify all of the amax history buffers got updated
+        amax_history_buffer_names = [
+            'fp8_amax_history_x',
+            'fp8_amax_history_w',
+            'fp8_amax_history_y',
+            'fp8_amax_history_dL_dX',
+            'fp8_amax_history_dL_dW',
+            'fp8_amax_history_dL_dY',
+        ]
+        for buffer_name in amax_history_buffer_names:
+            buffer_value = getattr(m_fp8, buffer_name)
+            self.assertTrue(torch.max(buffer_value) > 0.0, f"{buffer_name} not filled")
 
         # verify initialization buffers got updated
         self.assertTrue(m_fp8.fw_amax_initialized[0] == 1)


### PR DESCRIPTION
Summary:

This PR implements a very simple version of delayed scaling. For now, this just does the following:
1. have a history for each amax buffer
2. when current amax is calculated, ensure it is recorded in the history

Some things we need to do in future PRs:
a. calculate the current scale based on history (currently it just uses the last value) b. clean up float8 casts handling to make it look more like TE's fused casts

A couple of PRs later, this will be able to mimic
https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html#Mixed-precision-training-with-FP8

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: