### PR TITLE
switch casts to float8 to be saturated

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -8,6 +8,9 @@ from torch.library import Library
 
 from float8_utils import (
     tensor_to_amax,
+    to_fp8_saturated,
+    E4M3_MAX_POS,
+    E5M2_MAX_POS,
 )
 
 
@@ -30,7 +33,7 @@ def mm_float8(
     amax3.fill_(tensor_to_amax(m3_fp32))
 
     m3_fp32_scaled = m3_fp32 * s3
-    return m3_fp32_scaled.to(dtype3)
+    return to_fp8_saturated(m3_fp32_scaled, dtype3)
 
 # TODO naming of these vars is weird
 def addmm_float8(
@@ -53,7 +56,7 @@ def addmm_float8(
     amax3.fill_(tensor_to_amax(m3_fp32))
 
     m3_fp32_scaled = m3_fp32 * s3
-    return m3_fp32_scaled.to(dtype3)
+    return to_fp8_saturated(m3_fp32_scaled, dtype3)
 
 
 #

--- a/float8_playground/float8_tensor.py
+++ b/float8_playground/float8_tensor.py
@@ -2,7 +2,10 @@ from enum import Enum
 import torch
 from torch.utils._pytree import tree_map
 
-from float8_utils import tensor_to_amax
+from float8_utils import (
+    tensor_to_amax,
+    to_fp8_saturated,
+)
 
 aten = torch.ops.aten
 
@@ -27,7 +30,7 @@ class ToFloat8ConstrFunc(torch.autograd.Function):
             amax_buffer.fill_(tensor_to_amax(tensor))
 
         tensor_scaled = tensor * scale
-        bits_fp8 = tensor_scaled.to(float8_dtype)
+        bits_fp8 = to_fp8_saturated(tensor_scaled, float8_dtype)
         return Float8Tensor(bits_fp8, scale, tensor.dtype)
 
     @staticmethod

--- a/float8_playground/float8_utils.py
+++ b/float8_playground/float8_utils.py
@@ -35,6 +35,19 @@ def tensor_to_scale(x, dtype):
     amax = tensor_to_amax(x)
     return amax_to_scale(amax, dtype)
 
+def to_fp8_saturated(x, float8_dtype):
+    # The default behavior in PyTorch for casting to `float8_e4m3fn`
+    # and `e5m2` is to not saturate. In this context, we should saturate.
+    # A common case where we want to saturate is when the history of a 
+    # tensor has a maximum value of `amax1`, and the current amax value
+    # is `amax2`, where `amax1 < amax2`. This is common when using delayed
+    # scaling.
+    if float8_dtype == torch.float8_e4m3fn:
+        x = x.clamp(min=-1*E4M3_MAX_POS, max=E4M3_MAX_POS)
+    else:
+        x = x.clamp(min=-1*E5M2_MAX_POS, max=E5M2_MAX_POS)
+    return x.to(float8_dtype)
+
 def compute_error(x, y):
     Ps = torch.norm(x)
     Pn = torch.norm(x - y)


### PR DESCRIPTION
Summary:

In https://github.com/pytorch-labs/float8_playground/pull/18, the MNIST finetuning script broke because the casts were not saturated.

By default, casts to float8 are not saturated. With delayed scaling, we need to saturate to avoid `NaN`s everywhere.  For now, write the saturation logic in eager mode.

In the future we would ideally lower this to a hardware accelerated saturated cast via PT2.0.

Test Plan:

```
// loss now converges, again
with-proxy python finetune/mnist.py --batch-size 4096 --use-pt-fp8
```

Reviewers:

Subscribers:

Tasks:

Tags: