### PR TITLE
add delayed scaling config, and switch scale calculation to use history

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -7,6 +7,8 @@ as stateful scaling can be implemented. For now, we expect framework
 owners to implement their own UEX.
 """
 
+import dataclasses
+
 import torch
 
 from float8_linear_utils import (
@@ -23,7 +25,7 @@ from float8_python_api import (
 
 from float8_utils import (
     tensor_to_amax,
-    amax_to_scale,
+    amax_history_to_scale,
     E4M3_MAX_POS,
     E5M2_MAX_POS,
 )
@@ -48,12 +50,14 @@ class float8_linear(torch.autograd.Function):
         fp8_amax_history_dL_dW,
         fw_amax_initialized,
         bw_amax_initialized,
+        recipe,
     ):
         ctx.save_for_backward(
             x_fp8, w_fp8, b, 
             fp8_amax_dL_dX, fp8_amax_history_dL_dX,
             fp8_amax_dL_dW, fp8_amax_history_dL_dW,
             bw_amax_initialized)
+        ctx.recipe = recipe
         orig_shape = x_fp8._data.shape
         x_fp8_reshaped = x_fp8.reshape(-1, orig_shape[-1])
         is_fw_amax_initialized = torch.any(fw_amax_initialized)
@@ -63,8 +67,8 @@ class float8_linear(torch.autograd.Function):
                 b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
                 is_fw_amax_initialized)
 
-            # TODO(next): calculate scale based on history here
-            y_scale = amax_to_scale(fp8_amax_y, torch.float8_e4m3fn)
+            y_scale = amax_history_to_scale(
+                fp8_amax_history_y, torch.float8_e4m3fn, recipe.scale_fn_name)
             res_bits = addmm_float8(
                 b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale, 
                 torch.float8_e4m3fn)
@@ -75,8 +79,8 @@ class float8_linear(torch.autograd.Function):
                 x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
                 is_fw_amax_initialized)
 
-            # TODO(next): calculate scale based on history here
-            y_scale = amax_to_scale(fp8_amax_y, torch.float8_e4m3fn)
+            y_scale = amax_history_to_scale(
+                fp8_amax_history_y, torch.float8_e4m3fn, recipe.scale_fn_name)
             res_bits = mm_float8(
                 x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale, 
                 torch.float8_e4m3fn)
@@ -91,6 +95,7 @@ class float8_linear(torch.autograd.Function):
         x_fp8, w_fp8, b_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, \
             fp8_amax_dL_dW, fp8_amax_history_dL_dW, bw_amax_initialized = \
                 ctx.saved_tensors
+        recipe = ctx.recipe
                 
         is_bw_amax_initialized = torch.any(bw_amax_initialized)
 
@@ -104,8 +109,8 @@ class float8_linear(torch.autograd.Function):
             go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, 
             is_bw_amax_initialized)
 
-        # TODO(next): calculate scale based on history here
-        dL_dX_scale = amax_to_scale(fp8_amax_dL_dX, torch.float8_e5m2)
+        dL_dX_scale = amax_history_to_scale(
+            fp8_amax_history_dL_dX, torch.float8_e5m2, recipe.scale_fn_name)
         dL_dX_bits = mm_float8(
             go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, dL_dX_scale, torch.float8_e5m2)
         _update_history_with_new_amax(fp8_amax_dL_dX, fp8_amax_history_dL_dX)
@@ -122,8 +127,8 @@ class float8_linear(torch.autograd.Function):
             x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, fp8_amax_history_dL_dW,
             is_bw_amax_initialized)
 
-        # TODO(next): calculate scale based on history here
-        dL_dW_scale = amax_to_scale(fp8_amax_dL_dW, torch.float8_e5m2)
+        dL_dW_scale = amax_history_to_scale(
+            fp8_amax_history_dL_dW, torch.float8_e5m2, recipe.scale_fn_name)
         dL_dW_bits = mm_float8(
             x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, 
             dL_dW_scale, torch.float8_e5m2).t()
@@ -133,7 +138,7 @@ class float8_linear(torch.autograd.Function):
         if not is_bw_amax_initialized:
             bw_amax_initialized.fill_(1)
 
-        empty_grads = None, None, None, None, None, None, None, None, None
+        empty_grads = None, None, None, None, None, None, None, None, None, None
         if b_fp8 is not None:
             return dL_dX_fp8, dL_dW_fp8, go_fp8, *empty_grads
         else:
@@ -141,28 +146,40 @@ class float8_linear(torch.autograd.Function):
 
 class _NoOpFwToFloat8E5M2Bw(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized):
+    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized, recipe):
         ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized)
+        ctx.recipe = recipe
         return x
 
     @staticmethod
     def backward(ctx, go):
         fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized = ctx.saved_tensors
+        recipe = ctx.recipe
         is_bw_amax_initialized = torch.any(bw_amax_initialized)
         if not isinstance(go, Float8Tensor):
-            # TODO(future): switch to windowed delayed scaling
             with torch.no_grad():
                 _maybe_initialize_amaxes_for_float8_cast(
                     go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_bw_amax_initialized)
-                # TODO(next): calculate scale based on history here
-                dL_dY_scale = amax_to_scale(fp8_amax_dL_dY, torch.float8_e5m2)
+                dL_dY_scale = amax_history_to_scale(
+                    fp8_amax_history_dL_dY, torch.float8_e5m2, recipe.scale_fn_name)
                 go_fp8 = Float8Tensor.to_float8(
                     go, dL_dY_scale, torch.float8_e5m2, fp8_amax_dL_dY)
                 _update_history_with_new_amax(
                     fp8_amax_dL_dY, fp8_amax_history_dL_dY)
         else:
             go_fp8 = go
-        return go_fp8, None, None, None
+        return go_fp8, None, None, None, None
+
+@dataclasses.dataclass
+class DelayedScalingRecipe:
+    # Controls the history length of amax buffers
+    # TODO(future): make default history_len more representative for real usage,
+    # current value is for debugging
+    history_len = 4
+
+    # Controls the way to calculate current scale from amax history
+    # TODO(future): add other functions as needed, hardcoded or user defined
+    scale_fn_name = 'max'
 
 class Float8Linear(torch.nn.Linear):
     """
@@ -170,10 +187,15 @@ class Float8Linear(torch.nn.Linear):
     scales in way friendly to delayed scaling.
     """
     def __init__(self, *args, **kwargs):
+        delayed_scaling_recipe = kwargs.pop('delayed_scaling_recipe', DelayedScalingRecipe())
         super().__init__(*args, **kwargs)
-        # TODO(future): make history_len configurable, for now it's a default
-        # set for easy debugging
-        history_len = 4
+
+        # TODO(future): have a unique recipe per buffer instead of one per 
+        # module, saving implementing that until we need it.
+        # TODO(future): serialization for recipes
+        self.recipe = delayed_scaling_recipe
+        history_len = self.recipe.history_len
+
         self.register_buffer('fp8_amax_x', torch.tensor(E4M3_MAX_POS))
         self.register_buffer('fp8_amax_history_x', torch.zeros(history_len))
         self.register_buffer('fp8_amax_w', torch.tensor(E4M3_MAX_POS))
@@ -199,11 +221,11 @@ class Float8Linear(torch.nn.Linear):
                 # if we need CPU support in the future, we can add it
                 x = x.to(torch.get_autocast_gpu_dtype())
 
-            # TODO(future): switch to windowed delayed scaling
             _maybe_initialize_amaxes_for_float8_cast(
                 x, self.fp8_amax_x, self.fp8_amax_history_x, is_fw_amax_initialized)
-            # TODO(next): calculate state from history
-            x_scale = amax_to_scale(self.fp8_amax_x, torch.float8_e4m3fn)
+            x_scale = amax_history_to_scale(
+                self.fp8_amax_history_x, torch.float8_e4m3fn,
+                self.recipe.scale_fn_name)
             x_fp8 = Float8Tensor.to_float8(
                 x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
             _update_history_with_new_amax(
@@ -211,11 +233,11 @@ class Float8Linear(torch.nn.Linear):
         else:
             x_fp8 = x
 
-        # TODO(future): switch to windowed delayed scaling
         _maybe_initialize_amaxes_for_float8_cast(
             self.weight, self.fp8_amax_w, self.fp8_amax_history_w, is_fw_amax_initialized)
-        # TODO(next): calculate state from history
-        w_scale = amax_to_scale(self.fp8_amax_w, torch.float8_e4m3fn)
+        w_scale = amax_history_to_scale(
+            self.fp8_amax_history_w, torch.float8_e4m3fn,
+            self.recipe.scale_fn_name)
         w_fp8 = Float8Tensor.to_float8(
             self.weight, w_scale, torch.float8_e4m3fn, self.fp8_amax_w)
         _update_history_with_new_amax(
@@ -226,14 +248,15 @@ class Float8Linear(torch.nn.Linear):
             self.fp8_amax_y, self.fp8_amax_history_y, 
             self.fp8_amax_dL_dX, self.fp8_amax_history_dL_dX,
             self.fp8_amax_dL_dW, self.fp8_amax_history_dL_dW,
-            self.fw_amax_initialized, self.bw_amax_initialized)
+            self.fw_amax_initialized, self.bw_amax_initialized, self.recipe)
 
         if not is_fw_amax_initialized:
             self.fw_amax_initialized.fill_(1)
 
         # Set up cast to fp8 in bw
         y_fp8 = _NoOpFwToFloat8E5M2Bw.apply(
-            y_fp8, self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY, self.bw_amax_initialized)
+            y_fp8, self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY, 
+            self.bw_amax_initialized, self.recipe)
 
         # For now, hardcode returning Float8Tensor (propagate as much as we can).
         # This can be changed to return a different dtype, if needed.

--- a/float8_playground/float8_utils.py
+++ b/float8_playground/float8_utils.py
@@ -20,6 +20,13 @@ def amax_to_scale(amax, dtype):
         return E5M2_MAX_POS / torch.clamp(amax, min=EPS)
 
 @torch.no_grad()
+def amax_history_to_scale(amax_history, float8_dtype, history_to_scale_fn_type):
+    if history_to_scale_fn_type == 'max':
+        amax = torch.max(amax_history)
+        return amax_to_scale(amax, float8_dtype)
+    raise NotImplementedError()
+
+@torch.no_grad()
 def tensor_to_amax(x):
     amax = torch.max(torch.abs(x))
     amax_copy = amax.detach().clone()


### PR DESCRIPTION
Summary:

1. adds a basic config for delayed scaling
2. switches scale calculation to look at the history instead of the current scale

Test Plan:

```
// tests pass
with-proxy ./tests/test_everything.sh
// example finetuning still converges
with-proxy python finetune/mnist.py --batch-size 4096 --use-pt-fp8
```

Reviewers:

Subscribers:

Tasks:

Tags: