### PR TITLE
Wire up scaled_gemm to addmm_float8

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -35,7 +35,7 @@ def mm_float8_emulated(
 
 
 # TODO naming of these vars is weird
-def addmm_float8(
+def addmm_float8_emulated(
     inp1,  # bias (in fp32/fp16/bf16, no fp8 support)
     m1,  # input 1 data
     s1,  # input 1 scale
@@ -70,6 +70,6 @@ lib.define("mm_float8_emulated(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tenso
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CPU")
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CUDA")
 
-lib.define("addmm_float8(Tensor inp1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, Tensor s3, ScalarType dtype3) -> Tensor")
-lib.impl("addmm_float8", addmm_float8, "CPU")
-lib.impl("addmm_float8", addmm_float8, "CUDA")
+lib.define("addmm_float8_emulated(Tensor inp1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor amax3, Tensor s3, ScalarType dtype3) -> Tensor")
+lib.impl("addmm_float8_emulated", addmm_float8_emulated, "CPU")
+lib.impl("addmm_float8_emulated", addmm_float8_emulated, "CUDA")

--- a/float8_playground/float8_linear_nots.py
+++ b/float8_playground/float8_linear_nots.py
@@ -94,7 +94,7 @@ class float8_linear_no_tensor_subclass(torch.autograd.Function):
 
             y_scale = amax_history_to_scale(
                 fp8_amax_history_y, torch.float8_e4m3fn, recipe.scale_fn_name)
-            res_bits = torch.ops.aten.addmm_float8(
+            res_bits = torch.ops.aten.addmm_float8_emulated(
                 b, x_fp8_reshaped, x_fp8_scale, w_fp8_d.t(), w_fp8_scale,
                 fp8_amax_y, y_scale, torch.float8_e4m3fn)
             _update_history_with_new_amax(fp8_amax_y, fp8_amax_history_y)


### PR DESCRIPTION
# Summary this wires up the addmm_float8 function to be able to call scaled_gemm when not emulating.

## NOTE
Currently the numerics are note working very well at all. Need to figure out why/where this is coming from