### PR TITLE
simplify init buffers

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -49,26 +49,24 @@ class float8_linear(torch.autograd.Function):
         fp8_amax_history_dL_dX,
         fp8_amax_dL_dW,
         fp8_amax_history_dL_dW,
-        fw_amax_initialized,
-        bw_amax_initialized,
+        is_amax_initialized,
         scale_fn_name,
         emulate: bool,
     ):
         ctx.save_for_backward(
             x_fp8, w_fp8, b,
             fp8_amax_dL_dX, fp8_amax_history_dL_dX,
-            fp8_amax_dL_dW, fp8_amax_history_dL_dW,
-            bw_amax_initialized)
+            fp8_amax_dL_dW, fp8_amax_history_dL_dW)
         ctx.scale_fn_name = scale_fn_name
         ctx.emulate = emulate
         orig_shape = x_fp8._data.shape
         x_fp8_reshaped = x_fp8.reshape(-1, orig_shape[-1])
-        is_fw_amax_initialized = torch.any(fw_amax_initialized)
+        ctx.is_amax_initialized = is_amax_initialized
 
         if b is not None:
             _maybe_initialize_amaxes_for_addmm(
                 b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
-                is_fw_amax_initialized)
+                is_amax_initialized)
 
             y_scale = amax_history_to_scale(
                 fp8_amax_history_y, torch.float8_e4m3fn, scale_fn_name)
@@ -80,7 +78,7 @@ class float8_linear(torch.autograd.Function):
         else:
             _maybe_initialize_amaxes_for_mm(
                 x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
-                is_fw_amax_initialized)
+                is_amax_initialized)
 
             y_scale = amax_history_to_scale(
                 fp8_amax_history_y, torch.float8_e4m3fn, scale_fn_name)
@@ -96,12 +94,11 @@ class float8_linear(torch.autograd.Function):
     @staticmethod
     def backward(ctx, go_fp8):
         x_fp8, w_fp8, b_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, \
-            fp8_amax_dL_dW, fp8_amax_history_dL_dW, bw_amax_initialized = \
+            fp8_amax_dL_dW, fp8_amax_history_dL_dW = \
                 ctx.saved_tensors
         scale_fn_name = ctx.scale_fn_name
         emulate = ctx.emulate
-
-        is_bw_amax_initialized = torch.any(bw_amax_initialized)
+        is_amax_initialized = ctx.is_amax_initialized
 
         go_fp8_orig_shape = go_fp8._data.shape
         go_fp8_reshaped = go_fp8.reshape(-1, go_fp8_orig_shape[-1])
@@ -111,7 +108,7 @@ class float8_linear(torch.autograd.Function):
         #
         _maybe_initialize_amaxes_for_mm(
             go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX,
-            is_bw_amax_initialized)
+            is_amax_initialized)
 
         dL_dX_scale = amax_history_to_scale(
             fp8_amax_history_dL_dX, torch.float8_e5m2, scale_fn_name)
@@ -129,7 +126,7 @@ class float8_linear(torch.autograd.Function):
         #
         _maybe_initialize_amaxes_for_mm(
             x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, fp8_amax_history_dL_dW,
-            is_bw_amax_initialized)
+            is_amax_initialized)
 
         dL_dW_scale = amax_history_to_scale(
             fp8_amax_history_dL_dW, torch.float8_e5m2, scale_fn_name)
@@ -139,9 +136,6 @@ class float8_linear(torch.autograd.Function):
         _update_history_with_new_amax(fp8_amax_dL_dW, fp8_amax_history_dL_dW)
         dL_dW_fp8 = Float8Tensor(dL_dW_bits, dL_dW_scale, go_fp8._orig_dtype)
 
-        if not is_bw_amax_initialized:
-            bw_amax_initialized.fill_(1)
-
         empty_grads = None, None, None, None, None, None, None, None, None, None, None
         if b_fp8 is not None:
             return dL_dX_fp8, dL_dW_fp8, go_fp8, *empty_grads
@@ -150,21 +144,22 @@ class float8_linear(torch.autograd.Function):
 
 class _NoOpFwToFloat8E5M2Bw(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized, scale_fn_name):
-        ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized)
+    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_amax_initialized, scale_fn_name):
+        ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY)
         ctx.scale_fn_name = scale_fn_name
+        ctx.is_amax_initialized = is_amax_initialized
         return x
 
     @staticmethod
     def backward(ctx, go):
-        fp8_amax_dL_dY, fp8_amax_history_dL_dY, bw_amax_initialized = ctx.saved_tensors
+        fp8_amax_dL_dY, fp8_amax_history_dL_dY = ctx.saved_tensors
         scale_fn_name = ctx.scale_fn_name
-        is_bw_amax_initialized = torch.any(bw_amax_initialized)
+        is_amax_initialized = ctx.is_amax_initialized
 
         if not isinstance(go, Float8Tensor):
             with torch.no_grad():
                 _maybe_initialize_amaxes_for_float8_cast(
-                    go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_bw_amax_initialized)
+                    go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_amax_initialized)
                 dL_dY_scale = amax_history_to_scale(
                     fp8_amax_history_dL_dY, torch.float8_e5m2, scale_fn_name)
                 go_fp8 = Float8Tensor.to_float8(
@@ -213,13 +208,12 @@ class Float8Linear(torch.nn.Linear):
         self.register_buffer('fp8_amax_history_dL_dW', torch.zeros(history_len))
         self.register_buffer('fp8_amax_dL_dY', torch.tensor(E5M2_MAX_POS))
         self.register_buffer('fp8_amax_history_dL_dY', torch.zeros(history_len))
-        self.register_buffer('fw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
-        self.register_buffer('bw_amax_initialized', torch.tensor([0], dtype=torch.uint8))
+        self.register_buffer('amax_initialized', torch.tensor([0], dtype=torch.uint8))
         # Whether to emulate the fp8 matmul logic in float32
         self.emulate = False
 
     def forward(self, x):
-        is_fw_amax_initialized = torch.any(self.fw_amax_initialized)
+        is_amax_initialized = torch.any(self.amax_initialized)
         scale_fn_name = self.recipe.scale_fn_name
         if not isinstance(x, Float8Tensor):
             # Duplicate the autocast logic for F.linear, so that the output
@@ -230,7 +224,7 @@ class Float8Linear(torch.nn.Linear):
                 x = x.to(torch.get_autocast_gpu_dtype())
 
             _maybe_initialize_amaxes_for_float8_cast(
-                x, self.fp8_amax_x, self.fp8_amax_history_x, is_fw_amax_initialized)
+                x, self.fp8_amax_x, self.fp8_amax_history_x, is_amax_initialized)
             x_scale = amax_history_to_scale(
                 self.fp8_amax_history_x, torch.float8_e4m3fn, scale_fn_name)
             x_fp8 = Float8Tensor.to_float8(
@@ -241,7 +235,7 @@ class Float8Linear(torch.nn.Linear):
             x_fp8 = x
 
         _maybe_initialize_amaxes_for_float8_cast(
-            self.weight, self.fp8_amax_w, self.fp8_amax_history_w, is_fw_amax_initialized)
+            self.weight, self.fp8_amax_w, self.fp8_amax_history_w, is_amax_initialized)
         w_scale = amax_history_to_scale(
             self.fp8_amax_history_w, torch.float8_e4m3fn, scale_fn_name)
         w_fp8 = Float8Tensor.to_float8(
@@ -254,16 +248,15 @@ class Float8Linear(torch.nn.Linear):
             self.fp8_amax_y, self.fp8_amax_history_y,
             self.fp8_amax_dL_dX, self.fp8_amax_history_dL_dX,
             self.fp8_amax_dL_dW, self.fp8_amax_history_dL_dW,
-            self.fw_amax_initialized, self.bw_amax_initialized, scale_fn_name, 
-            self.emulate)
+            is_amax_initialized, scale_fn_name, self.emulate)
 
-        if not is_fw_amax_initialized:
-            self.fw_amax_initialized.fill_(1)
+        if not is_amax_initialized:
+            self.amax_initialized.fill_(1)
 
         # Set up cast to fp8 in bw
         y_fp8 = _NoOpFwToFloat8E5M2Bw.apply(
             y_fp8, self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY,
-            self.bw_amax_initialized, scale_fn_name)
+            is_amax_initialized, scale_fn_name)
 
         # For now, hardcode returning Float8Tensor (propagate as much as we can).
         # This can be changed to return a different dtype, if needed.

--- a/tests/test.py
+++ b/tests/test.py
@@ -121,8 +121,7 @@ class TestFloat8Linear:
             assert torch.max(buffer_value) > 0.0, f"{buffer_name} not filled"
 
         # verify initialization buffers got updated
-        assert (m_fp8.fw_amax_initialized[0] == 1)
-        assert (m_fp8.bw_amax_initialized[0] == 1)
+        assert (m_fp8.amax_initialized[0] == 1)
 
     @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize("x_shape", [(16, 16),(2, 16, 16), (3, 2, 16, 16)])


### PR DESCRIPTION
Summary:

We don't need two buffers to track init state, can just use one.

This will simplify making this control flow traceable in a future PR.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: