### PR TITLE
make pt2 test use aot_eager

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -185,7 +185,7 @@ class TestFloat8Linear:
             m = Float8LinearNoTensorSubclass.from_float(m, emulate=True)
         else:
             m = Float8Linear.from_float(m)
-        m = torch.compile(m, backend=cnt, fullgraph=True)
+        m = torch.compile(m, backend='aot_eager', fullgraph=True)
         # verify things don't crash
         m(x)
         # TODO(future): inspect the graph programmaticaly


### PR DESCRIPTION
Summary:

Moves the pt2 test from eager to aot_eager.

This needs https://github.com/pytorch/pytorch/pull/107642 to land to pass.

Test Plan:

```
// we see the full emulated fw + bw graph in the logs
TORCH_LOGS="aot" pytest tests/test.py -k pt2_nots -s
```

Reviewers:

Subscribers:

Tasks:

Tags: