### PR TITLE
[wip] exploration to make tensor subclasses pass dynamo tracing

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -29,8 +29,12 @@ from float8_utils import (
     amax_history_to_scale,
     E4M3_MAX_POS,
     E5M2_MAX_POS,
+    to_fp8_saturated,
 )
-from float8_tensor import Float8Tensor
+from float8_tensor import (
+    Float8Tensor,
+    ToFloat8ConstrFunc,
+)
 
 class float8_linear(torch.autograd.Function):
     """
@@ -234,8 +238,17 @@ class Float8Linear(torch.nn.Linear):
                 is_amax_initialized_this_iteration)
             x_scale = amax_history_to_scale(
                 self.fp8_amax_history_x, torch.float8_e4m3fn, scale_fn_name)
-            x_fp8 = Float8Tensor.to_float8(
-                x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
+            # x_fp8 = Float8Tensor.to_float8(
+            #     x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
+            # x_fp8 = ToFloat8ConstrFunc.apply(
+            #     x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
+            x_fp8 = ToFloat8ConstrFunc.apply(
+                x, x_scale, self.fp8_amax_x)
+
+            # tensor_scaled = x * x_scale
+            # bits_fp8 = to_fp8_saturated(tensor_scaled, torch.float8_e4m3fn)
+            # x_fp8 = Float8Tensor(bits_fp8, x_scale, x.dtype)
+
             _update_history_with_new_amax(
                 self.fp8_amax_x, self.fp8_amax_history_x)
         else:
@@ -246,8 +259,12 @@ class Float8Linear(torch.nn.Linear):
             is_amax_initialized_this_iteration)
         w_scale = amax_history_to_scale(
             self.fp8_amax_history_w, torch.float8_e4m3fn, scale_fn_name)
-        w_fp8 = Float8Tensor.to_float8(
-            self.weight, w_scale, torch.float8_e4m3fn, self.fp8_amax_w)
+        # w_fp8 = Float8Tensor.to_float8(
+        #     self.weight, w_scale, torch.float8_e4m3fn, self.fp8_amax_w)
+        # w_fp8 = ToFloat8ConstrFunc.apply(
+        #     self.weight, w_scale, torch.float8_e4m3fn, self.fp8_amax_w)
+        w_fp8 = ToFloat8ConstrFunc.apply(
+            self.weight, w_scale, self.fp8_amax_w)
         _update_history_with_new_amax(
             self.fp8_amax_w, self.fp8_amax_history_w)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -193,7 +193,7 @@ class TestFloat8Linear:
         if use_no_tensor_subclass:
             m = Float8LinearNoTensorSubclass.from_float(m, emulate=True)
         else:
-            m = Float8Linear.from_float(m)
+            m = Float8Linear.from_float(m, emulate=True)
         m = torch.compile(m, backend=cnt, fullgraph=True)
         # verify things don't crash
         m(x)
@@ -205,8 +205,10 @@ class TestFloat8Linear:
     def test_pt2_nots(self):
         self._test_pt2_impl(use_no_tensor_subclass=True)
 
-    @unittest.skip("PT2.0 tracing subclasses does not work yet")
+    # @unittest.skip("PT2.0 tracing subclasses does not work yet")
     def test_pt2_ts(self):
+        from torch._dynamo import allow_in_graph
+        allow_in_graph(Float8Tensor)
         self._test_pt2_impl(use_no_tensor_subclass=False)
 
 class TestScaledMM:

--- a/tests/test_dynamo.py
+++ b/tests/test_dynamo.py
@@ -1,0 +1,200 @@
+import context
+
+import torch
+from torch.utils._pytree import tree_map
+from torch.utils._mode_utils import no_dispatch
+
+from float8_tensor import ToFloat8ConstrFunc, Float8Tensor
+
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, DTensor, Shard
+
+class FooTensor(torch.Tensor):
+    """
+    This is a tensor subclass similar to `Float8Tensor` which I am using
+    to debug why tracing with PT2.0 + eager backend is broken.
+    """
+    @staticmethod
+    def __new__(cls, data, config, scale):
+        self = torch.Tensor._make_wrapper_subclass(
+            cls,
+            # data.size(),
+            # strides=data.stride(),
+            # storage_offset=data.storage_offset(),
+            # dtype=data.dtype,
+            # layout=data.layout,
+            # requires_grad=data.requires_grad,
+            config[0], 
+            strides=config[1],
+            storage_offset=config[2],
+            dtype=config[3],
+            layout=config[4],
+            requires_grad=config[5],
+            device=data.device,
+        )
+        self._data = data
+        self._config = config
+        self._scale = scale
+        return self
+
+    def __repr__(self):
+        # having a real __repr__ masks some useful stack traces, comment it out for now
+        # return f"FooTensor(dtype={self._data.dtype}, scale={self._scale}, data={self._data})"
+        return f"FooTensor"
+
+    def __tensor_flatten__(self):
+        return (self._data,), (self._config, self._scale,)
+
+    @staticmethod
+    def __tensor_unflatten__(tensors, metadatas):
+        return FooTensor(tensors[0], metadatas[0], metadatas[1])
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs=None):
+        with no_dispatch():
+            print('func', func, type(func), types, args, kwargs)
+
+        # DTensor is not doing special handling for clone, and we probably should not either
+        if func == torch.ops.aten.clone.default:
+            # is this right? ideally this should work without special handling
+            return FooTensor(args[0]._data.clone(), args[0]._config, args[0]._scale)
+        elif func == torch.ops.aten.view.default:
+            # is this right? ideally this should work without special handling
+            new_data = args[0]._data.view(*args[1:])
+            return FooTensor(new_data, args[0]._config, args[0]._scale)
+
+        raise NotImplementedError()
+
+        # for all ops that get here, for `Float8Tensor` we want to fall back 
+        # to original precision, so we unwrap
+        def unwrap(t):
+            if isinstance(t, FooTensor):
+                return t._data
+            return t
+
+        args = tree_map(unwrap, args)
+        if kwargs is not None:
+            kwargs = tree_map(unwrap, kwargs)
+        with no_dispatch():
+            print('new args', args, kwargs)
+        out = super().__torch_dispatch__(func, types, args, kwargs)
+        return out
+
+    # Do not force the FooTensor type on the returned tensor
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+class foo_autograd_fn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        x2 = x._data + 1.0
+        x3 = FooTensor(x2, x._config, x._scale)
+        return x3
+
+    @staticmethod
+    def backward(ctx, g):
+        return g
+        
+def run_foo():
+    x = torch.zeros(4, 4)
+    scale = torch.tensor(1.0)
+    orig_dtype = torch.float
+
+    from torch._dynamo import allow_in_graph
+    allow_in_graph(FooTensor)
+
+    def foo(x, scale):
+        config = (x.size(), x.stride(), x.storage_offset(), x.dtype, x.layout, x.requires_grad)
+        x = FooTensor(x, config, scale)
+        x = foo_autograd_fn.apply(x)
+        return x
+        # return (x._data * x._scale) + x._data
+
+    foo = torch.compile(foo, backend='eager')
+    print(x)
+    y = foo(x, scale)
+    print(y)
+
+def run_float8():
+    x = torch.ones(4, 4)
+    scale = torch.tensor(2.0)
+    orig_dtype = torch.float
+    config = {
+        'size': x.size(),
+        'strides': x.stride(),
+        'storage_offset': x.storage_offset(),
+    }
+    # config = (x.size(), x.stride(), x.storage_offset(), x.dtype, x.layout, x.requires_grad)
+
+    x = Float8Tensor(x, scale, x.dtype, config)
+
+    def foo(x):
+        x = foo_autograd_fn.apply(x)
+        return (x._data * x._scale) + x._data
+
+    foo = torch.compile(foo, backend='eager')
+    print(x)
+    y = foo(x)
+    print(y)
+
+def run_float8_harder():
+
+        
+    from torch._dynamo import allow_in_graph
+    allow_in_graph(Float8Tensor)
+
+    x = torch.ones(4, 4)
+    scale = torch.tensor(2.0)
+    orig_dtype = torch.float
+
+    def foo(x, scale, orig_dtype):
+
+        config = {
+            'size': x.size(),
+            'strides': x.stride(),
+            'storage_offset': x.storage_offset(),
+        }
+
+        x = Float8Tensor(x, scale, x.dtype, config)
+        # return x
+        x = foo_autograd_fn.apply(x)
+        return (x._data * x._scale) + x._data
+
+    # foo = torch.compile(foo, backend='eager')
+    print(x)
+    y = foo(x, scale, orig_dtype)
+    print(y)
+    
+
+
+def run_dtensor():
+    """
+    Known good example of tensor subclass + torch.compile with eager 
+    backend, we can run this to see how it's supposed to work
+    """
+
+    # copied from https://fburl.com/code/5pei3374
+    device = 'cpu'
+    world_size = 1
+    mesh = DeviceMesh(device, torch.arange(world_size))
+
+    # test passing in DTensor as inputs/outputs and run some tensor computation
+    def fn(x):
+        return x * x + 2
+
+    local_x = torch.randn(4, 4)
+
+    x = DTensor.from_local(local_x, mesh, [Shard(0)], run_check=False)
+    opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+    y = opt_fn(x)
+
+
+# torchrun --nproc_per_node 1 tests/test_dynamo.py
+if __name__ == '__main__':
+    # known good
+    # run_dtensor()
+    # print('done with dtensor\n\n')
+
+    # TODO make this work
+    # run_foo()
+
+    # run_float8()
+    run_float8_harder()


### PR DESCRIPTION
Summary:

Does not work e2e yet, putting up a PR to get some thoughts from @bdhirsh

What is here at a high level:
1. we would like to use tensor subclasses for colocating data + scale and for tricking autograd into thinking our tensors are high precision
2. we are ok with not using __torch_dispatch__, and removing product logic from there seems to significantly reduce the amount of dynamo errors.  Remove this for now.  Note, we still need to support clone and transpose, because dynamo uses those to fakify the tensor (I think).
3. after we remove __torch_dispatch__ from product logic, callsites need to use the underlying data directly.  This currently doesn't work if the callsite is inside of a HigherOrderOp (torch.autograd.Function).

Debugging (3) is as far as I got, TBD on if fixing (3) would fix the whole thing or unmask more issues.

Test Plan:

```
// run the test case used to debug this PR
TORCH_LOGS="aot" pytest tests/test.py -k pt2_ts -s
// note: most other tests will fail at the moment as the code in
// Float8Linear also needs updating, we can fix that after we get dynamo
// working

// feel free to ignore test_dynamo.py for now, it's debugging which isn't shareable yet
```

Reviewers:

Subscribers:

Tasks:

Tags: