### PR TITLE
make float8 matmul return original precision

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -27,11 +27,8 @@ def mm_float8_emulated(
     m2_fp32 = m2.float() / s2
     m3_fp32 = torch.mm(m1_fp32, m2_fp32)
 
-    # TODO(future): switch to delayed scaling
     amax3.fill_(tensor_to_amax(m3_fp32))
-
-    m3_fp32_scaled = m3_fp32 * s3
-    return to_fp8_saturated(m3_fp32_scaled, dtype3)
+    return m3_fp32.to(dtype3)
 
 
 # TODO naming of these vars is weird
@@ -51,11 +48,8 @@ def addmm_float8_emulated(
     m2_fp32 = m2.float() / s2
     m3_fp32 = torch.addmm(inp1, m1_fp32, m2_fp32)
 
-    # TODO(future): switch to delayed scaling
     amax3.fill_(tensor_to_amax(m3_fp32))
-
-    m3_fp32_scaled = m3_fp32 * s3
-    return to_fp8_saturated(m3_fp32_scaled, dtype3)
+    return m3_fp32.to(dtype3)
 
 
 #

--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -14,8 +14,6 @@ from typing import Optional
 
 from float8_linear_utils import (
     _maybe_initialize_amaxes_for_float8_cast,
-    _maybe_initialize_amaxes_for_mm,
-    _maybe_initialize_amaxes_for_addmm,
     _update_history_with_new_amax,
 )
 
@@ -34,7 +32,7 @@ from float8_tensor import Float8Tensor
 
 class float8_linear(torch.autograd.Function):
     """
-    Like F.linear, but with X, W, and Y in float8
+    Like F.linear, but with X and W in float8
     """
 
     @staticmethod
@@ -43,20 +41,18 @@ class float8_linear(torch.autograd.Function):
         x_fp8,
         w_fp8,
         b,
-        fp8_amax_y,
-        fp8_amax_history_y,
-        fp8_amax_dL_dX,
-        fp8_amax_history_dL_dX,
-        fp8_amax_dL_dW,
-        fp8_amax_history_dL_dW,
+        fp8_amax_dL_dY,
+        fp8_amax_history_dL_dY,
+        fp8_noop_amax,
+        fp8_noop_scale,
         is_amax_initialized,
         scale_fn_name,
         emulate: bool,
     ):
         ctx.save_for_backward(
             x_fp8, w_fp8, b,
-            fp8_amax_dL_dX, fp8_amax_history_dL_dX,
-            fp8_amax_dL_dW, fp8_amax_history_dL_dW)
+            fp8_amax_dL_dY, fp8_amax_history_dL_dY,
+            fp8_noop_amax, fp8_noop_scale)
         ctx.scale_fn_name = scale_fn_name
         ctx.emulate = emulate
         orig_shape = x_fp8._data.shape
@@ -64,111 +60,62 @@ class float8_linear(torch.autograd.Function):
         ctx.is_amax_initialized = is_amax_initialized
 
         if b is not None:
-            _maybe_initialize_amaxes_for_addmm(
-                b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
-                is_amax_initialized)
-
-            y_scale = amax_history_to_scale(
-                fp8_amax_history_y, torch.float8_e4m3fn, scale_fn_name)
             res_bits = addmm_float8(
-                b, x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale,
-                torch.float8_e4m3fn, emulate=emulate)
-            _update_history_with_new_amax(fp8_amax_y, fp8_amax_history_y)
-
+                b, x_fp8_reshaped, w_fp8.t(), fp8_noop_amax, fp8_noop_scale,
+                output_dtype=x_fp8._orig_dtype, emulate=emulate)
         else:
-            _maybe_initialize_amaxes_for_mm(
-                x_fp8_reshaped, w_fp8.t(), fp8_amax_y, fp8_amax_history_y,
-                is_amax_initialized)
-
-            y_scale = amax_history_to_scale(
-                fp8_amax_history_y, torch.float8_e4m3fn, scale_fn_name)
             res_bits = mm_float8(
-                x_fp8_reshaped, w_fp8.t(), fp8_amax_y, y_scale,
-                torch.float8_e4m3fn, emulate=emulate)
-            _update_history_with_new_amax(fp8_amax_y, fp8_amax_history_y)
+                x_fp8_reshaped, w_fp8.t(), fp8_noop_amax, fp8_noop_scale,
+                output_dtype=x_fp8._orig_dtype, emulate=emulate)
         res_bits = res_bits.reshape(*orig_shape[:-1], res_bits.shape[-1])
-
-        res = Float8Tensor(res_bits, y_scale, x_fp8._orig_dtype)
-        return res
+        return res_bits
 
     @staticmethod
-    def backward(ctx, go_fp8):
-        x_fp8, w_fp8, b_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX, \
-            fp8_amax_dL_dW, fp8_amax_history_dL_dW = \
+    def backward(ctx, go):
+        x_fp8, w_fp8, b_fp8, \
+            fp8_amax_dL_dY, fp8_amax_history_dL_dY, fp8_noop_amax, fp8_noop_scale = \
                 ctx.saved_tensors
         scale_fn_name = ctx.scale_fn_name
         emulate = ctx.emulate
         is_amax_initialized = ctx.is_amax_initialized
 
+        # cast incoming gradient to fp8
+        _maybe_initialize_amaxes_for_float8_cast(
+            go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, 
+            is_amax_initialized)
+        go_scale = amax_history_to_scale(
+            fp8_amax_history_dL_dY, torch.float8_e5m2, scale_fn_name)
+        go_fp8 = Float8Tensor.to_float8(
+            go, go_scale, torch.float8_e5m2, fp8_amax_dL_dY)
+        _update_history_with_new_amax(
+            fp8_amax_dL_dY, fp8_amax_history_dL_dY)
+
         go_fp8_orig_shape = go_fp8._data.shape
         go_fp8_reshaped = go_fp8.reshape(-1, go_fp8_orig_shape[-1])
 
         #
-        # calculate dL/dX, update relevant buffers along the way
+        # calculate dL/dX
         #
-        _maybe_initialize_amaxes_for_mm(
-            go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, fp8_amax_history_dL_dX,
-            is_amax_initialized)
-
-        dL_dX_scale = amax_history_to_scale(
-            fp8_amax_history_dL_dX, torch.float8_e5m2, scale_fn_name)
-        dL_dX_bits = mm_float8(
-            go_fp8_reshaped, w_fp8, fp8_amax_dL_dX, dL_dX_scale, torch.float8_e5m2, emulate=emulate)
-        _update_history_with_new_amax(fp8_amax_dL_dX, fp8_amax_history_dL_dX)
-        dL_dX_bits = dL_dX_bits.reshape(*go_fp8_orig_shape[:-1], dL_dX_bits.shape[-1])
-        dL_dX_fp8 = Float8Tensor(dL_dX_bits, dL_dX_scale, go_fp8._orig_dtype)
+        dL_dX = mm_float8(
+            go_fp8_reshaped, w_fp8, fp8_noop_amax, fp8_noop_scale, 
+            output_dtype=x_fp8._orig_dtype, emulate=emulate)
+        dL_dX = dL_dX.reshape(*go_fp8_orig_shape[:-1], dL_dX.shape[-1])
 
         x_fp8_orig_shape = x_fp8._data.shape
         x_fp8_reshaped = x_fp8.reshape(-1, x_fp8_orig_shape[-1])
 
         #
-        # calculate dL/dW, update relevant buffers along the way
+        # calculate dL/dW
         #
-        _maybe_initialize_amaxes_for_mm(
-            x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW, fp8_amax_history_dL_dW,
-            is_amax_initialized)
+        dL_dW = mm_float8(
+            x_fp8_reshaped.t(), go_fp8_reshaped, fp8_noop_amax,
+            fp8_noop_scale, output_dtype=x_fp8._orig_dtype, emulate=emulate).t()
 
-        dL_dW_scale = amax_history_to_scale(
-            fp8_amax_history_dL_dW, torch.float8_e5m2, scale_fn_name)
-        dL_dW_bits = mm_float8(
-            x_fp8_reshaped.t(), go_fp8_reshaped, fp8_amax_dL_dW,
-            dL_dW_scale, torch.float8_e5m2, emulate=emulate).t()
-        _update_history_with_new_amax(fp8_amax_dL_dW, fp8_amax_history_dL_dW)
-        dL_dW_fp8 = Float8Tensor(dL_dW_bits, dL_dW_scale, go_fp8._orig_dtype)
-
-        empty_grads = None, None, None, None, None, None, None, None, None, None, None
+        empty_grads = None, None, None, None, None, None, None, None
         if b_fp8 is not None:
-            return dL_dX_fp8, dL_dW_fp8, go_fp8, *empty_grads
+            return dL_dX, dL_dW, go, *empty_grads
         else:
-            return dL_dX_fp8, dL_dW_fp8, *empty_grads
-
-class _NoOpFwToFloat8E5M2Bw(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_amax_initialized, scale_fn_name):
-        ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY)
-        ctx.scale_fn_name = scale_fn_name
-        ctx.is_amax_initialized = is_amax_initialized
-        return x
-
-    @staticmethod
-    def backward(ctx, go):
-        fp8_amax_dL_dY, fp8_amax_history_dL_dY = ctx.saved_tensors
-        scale_fn_name = ctx.scale_fn_name
-        is_amax_initialized = ctx.is_amax_initialized
-
-        if not isinstance(go, Float8Tensor):
-            with torch.no_grad():
-                _maybe_initialize_amaxes_for_float8_cast(
-                    go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_amax_initialized)
-                dL_dY_scale = amax_history_to_scale(
-                    fp8_amax_history_dL_dY, torch.float8_e5m2, scale_fn_name)
-                go_fp8 = Float8Tensor.to_float8(
-                    go, dL_dY_scale, torch.float8_e5m2, fp8_amax_dL_dY)
-                _update_history_with_new_amax(
-                    fp8_amax_dL_dY, fp8_amax_history_dL_dY)
-        else:
-            go_fp8 = go
-        return go_fp8, None, None, None, None
+            return dL_dX, dL_dW, *empty_grads
 
 @dataclasses.dataclass
 class DelayedScalingRecipe:
@@ -200,14 +147,13 @@ class Float8Linear(torch.nn.Linear):
         self.register_buffer('fp8_amax_history_x', torch.zeros(history_len))
         self.register_buffer('fp8_amax_w', torch.tensor(E4M3_MAX_POS))
         self.register_buffer('fp8_amax_history_w', torch.zeros(history_len))
-        self.register_buffer('fp8_amax_y', torch.tensor(E4M3_MAX_POS))
-        self.register_buffer('fp8_amax_history_y', torch.zeros(history_len))
-        self.register_buffer('fp8_amax_dL_dX', torch.tensor(E5M2_MAX_POS))
-        self.register_buffer('fp8_amax_history_dL_dX', torch.zeros(history_len))
-        self.register_buffer('fp8_amax_dL_dW', torch.tensor(E5M2_MAX_POS))
-        self.register_buffer('fp8_amax_history_dL_dW', torch.zeros(history_len))
         self.register_buffer('fp8_amax_dL_dY', torch.tensor(E5M2_MAX_POS))
         self.register_buffer('fp8_amax_history_dL_dY', torch.zeros(history_len))
+        # The two buffers below are noops, we have them because 
+        # torch.scaled_mm requires arguments in case the output of the matmul
+        # is float8.
+        self.register_buffer('fp8_noop_amax', torch.tensor(float('inf')))
+        self.register_buffer('fp8_noop_scale', torch.tensor(1.0))
         # Whether to emulate the fp8 matmul logic in float32
         self.emulate = False
 
@@ -221,25 +167,22 @@ class Float8Linear(torch.nn.Linear):
         self.is_amax_initialized = True
         scale_fn_name = self.recipe.scale_fn_name
 
-        if not isinstance(x, Float8Tensor):
-            # Duplicate the autocast logic for F.linear, so that the output
-            # of our module has the right original precision
-            if torch.is_autocast_enabled():
-                # For now, hardcode to GPU's autocast dtype
-                # if we need CPU support in the future, we can add it
-                x = x.to(torch.get_autocast_gpu_dtype())
+        # Duplicate the autocast logic for F.linear, so that the output
+        # of our module has the right original precision
+        if torch.is_autocast_enabled():
+            # For now, hardcode to GPU's autocast dtype
+            # if we need CPU support in the future, we can add it
+            x = x.to(torch.get_autocast_gpu_dtype())
 
-            _maybe_initialize_amaxes_for_float8_cast(
-                x, self.fp8_amax_x, self.fp8_amax_history_x, 
-                is_amax_initialized_this_iteration)
-            x_scale = amax_history_to_scale(
-                self.fp8_amax_history_x, torch.float8_e4m3fn, scale_fn_name)
-            x_fp8 = Float8Tensor.to_float8(
-                x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
-            _update_history_with_new_amax(
-                self.fp8_amax_x, self.fp8_amax_history_x)
-        else:
-            x_fp8 = x
+        _maybe_initialize_amaxes_for_float8_cast(
+            x, self.fp8_amax_x, self.fp8_amax_history_x, 
+            is_amax_initialized_this_iteration)
+        x_scale = amax_history_to_scale(
+            self.fp8_amax_history_x, torch.float8_e4m3fn, scale_fn_name)
+        x_fp8 = Float8Tensor.to_float8(
+            x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
+        _update_history_with_new_amax(
+            self.fp8_amax_x, self.fp8_amax_history_x)
 
         _maybe_initialize_amaxes_for_float8_cast(
             self.weight, self.fp8_amax_w, self.fp8_amax_history_w, 
@@ -251,21 +194,13 @@ class Float8Linear(torch.nn.Linear):
         _update_history_with_new_amax(
             self.fp8_amax_w, self.fp8_amax_history_w)
 
-        y_fp8 = float8_linear.apply(
+        y = float8_linear.apply(
             x_fp8, w_fp8, self.bias,
-            self.fp8_amax_y, self.fp8_amax_history_y,
-            self.fp8_amax_dL_dX, self.fp8_amax_history_dL_dX,
-            self.fp8_amax_dL_dW, self.fp8_amax_history_dL_dW,
+            self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY,
+            self.fp8_noop_amax, self.fp8_noop_scale,
             is_amax_initialized_this_iteration, scale_fn_name, self.emulate)
 
-        # Set up cast to fp8 in bw
-        y_fp8 = _NoOpFwToFloat8E5M2Bw.apply(
-            y_fp8, self.fp8_amax_dL_dY, self.fp8_amax_history_dL_dY,
-            is_amax_initialized_this_iteration, scale_fn_name)
-
-        # For now, hardcode returning Float8Tensor (propagate as much as we can).
-        # This can be changed to return a different dtype, if needed.
-        return y_fp8
+        return y
 
     @classmethod
     def from_float(cls, mod, emulate: bool):

--- a/float8_playground/float8_linear_utils.py
+++ b/float8_playground/float8_linear_utils.py
@@ -17,63 +17,6 @@ def _maybe_initialize_amaxes_for_float8_cast(x, cur_amax, amax_history, is_initi
         cur_amax.fill_(new_amax)
         amax_history[0] = new_amax
 
-def _maybe_initialize_amaxes_for_mm(x1, x2, cur_amax, amax_history, is_initialized):
-    """
-    If we are about to run the float8 version of `torch.mm(x1, x2)` and the output
-    amax buffer is not initialized, initialize it inplace.
-    """
-    if is_initialized:
-        return
-    with torch.no_grad():
-        ref_result = torch.mm(x1, x2)            
-        new_amax = tensor_to_amax(ref_result)
-        cur_amax.fill_(new_amax)
-        amax_history[0] = new_amax
-
-def _maybe_initialize_amaxes_for_mm_decomposed(x1, x1_scale, x2, x2_scale, cur_amax, amax_history, is_initialized):
-    """
-    Temporary rewrite of `_maybe_initialize_amaxes_for_mm` without using
-    tensor subclass.
-    """
-    if is_initialized:
-        return
-    with torch.no_grad():
-        ref_result = torch.mm(x1.float() / x1_scale, x2.float() / x2_scale)            
-        new_amax = tensor_to_amax(ref_result)
-        cur_amax.fill_(new_amax)
-        amax_history[0] = new_amax
-
-def _maybe_initialize_amaxes_for_addmm(inp, x1, x2, cur_amax, amax_history, is_initialized):
-    """
-    If we are about to run the float8 version of `torch.addmm(inp, x1, x2)` and the output
-    amax buffer is not initialized, initialize it inplace.
-    """
-    if is_initialized:
-        return
-    with torch.no_grad():
-        ref_result = torch.addmm(inp, x1, x2)            
-        new_amax = tensor_to_amax(ref_result)
-        cur_amax.fill_(new_amax)
-        amax_history[0] = new_amax
-
-def _maybe_initialize_amaxes_for_addmm_decomposed(
-    inp, x1, x1_scale, x2, x2_scale, cur_amax, amax_history, 
-    is_initialized,
-):
-    """
-    Temporary rewrite of `_maybe_initialize_amaxes_for_addmm` without using
-    tensor subclass.
-    """
-    if is_initialized:
-        return
-    with torch.no_grad():
-        ref_result = torch.addmm(
-            inp, x1.float() / x1_scale, 
-            x2.float() / x2_scale)            
-        new_amax = tensor_to_amax(ref_result)
-        cur_amax.fill_(new_amax)
-        amax_history[0] = new_amax
-
 def _update_history_with_new_amax(new_amax, amax_history):
     """
     Updates `amax_history` (the last N cur_amax values) inplace with the value 

--- a/tests/test.py
+++ b/tests/test.py
@@ -101,9 +101,6 @@ class TestFloat8Linear:
         amax_buffer_names = [
             'fp8_amax_x',
             'fp8_amax_w',
-            'fp8_amax_y',
-            'fp8_amax_dL_dX',
-            'fp8_amax_dL_dW',
             'fp8_amax_dL_dY',
         ]
         for buffer_name in amax_buffer_names:
@@ -115,9 +112,6 @@ class TestFloat8Linear:
         amax_history_buffer_names = [
             'fp8_amax_history_x',
             'fp8_amax_history_w',
-            'fp8_amax_history_y',
-            'fp8_amax_history_dL_dX',
-            'fp8_amax_history_dL_dW',
             'fp8_amax_history_dL_dY',
         ]
         for buffer_name in amax_history_buffer_names:
@@ -174,12 +168,12 @@ class TestFloat8Linear:
         # autocast off
         x = torch.randn(16, 32, device='cuda')
         y = m(x)
-        assert y._orig_dtype == torch.float, f"y._orig_dtype is {y._orig_dtype}, expected {torch.float}"
+        assert y.dtype == torch.float, f"y.dtype is {y.dtype}, expected {torch.float}"
 
         # autocast on
         with torch.autocast('cuda'):
             y = m(x)
-        assert y._orig_dtype == torch.half, f"y._orig_dtype is {y._orig_dtype}, expected {torch.half}"
+        assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
 
     def _test_pt2_impl(self, use_no_tensor_subclass):
 


### PR DESCRIPTION
Summary:

1. it's rare for the output of a float8 op to be consumed by an fp8 enabled op (such as dual gemm)
2. for gradients, we want original precision anyway
3. TE does this

Because of ^, let's return original precision from matmuls. If someone needs the matmul to return float8, we can add that back at a later time.

One nice outcome is we can now match weight gradients between single node and fp16 FSDP.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: