### PR TITLE
[poc] scratch work on getting torch_dispatch subclass to play well wi…

### DIFF
--- a/tests/tmp.py
+++ b/tests/tmp.py
@@ -1,0 +1,49 @@
+import torch
+import context
+from float8_linear import Float8Linear
+from functorch.compile import aot_module_simplified, min_cut_rematerialization_partition
+from functools import partial
+from torch.fx.experimental.proxy_tensor import make_fx
+import torch.utils._pytree as pytree
+from torch._functorch.aot_autograd import create_functional_call
+
+def extract_graph(fx_g, _, graph_cell):
+    graph_cell[0] = fx_g
+    return fx_g
+
+m = torch.nn.Linear(4, 4, device='cpu', bias=False)
+x = torch.randn(4, 4, device='cpu')
+m = Float8Linear.from_float(m, emulate=True)
+import pdb; pdb.set_trace()
+m_compiled = torch.compile(m, backend="eager")
+out = m_compiled(x)
+
+params = {
+    **dict(m.named_parameters(remove_duplicate=False)),
+    **dict(m.named_buffers(remove_duplicate=False)),
+}
+params_flat, params_spec = pytree.tree_flatten(params)
+params_flat = list(params_flat)
+params_len = len(params_flat)
+functional_call = create_functional_call(m, params_spec, params_len)
+
+full_args = []
+full_args.extend(params_flat)
+full_args.extend([x])
+
+
+fw_cell, bw_cell = [None], [None]
+m_compiled = aot_module_simplified(
+    m,
+    (x,),
+    fw_compiler=partial(extract_graph, graph_cell=fw_cell),
+    bw_compiler=partial(extract_graph, graph_cell=bw_cell),
+    partition_fn=min_cut_rematerialization_partition,
+
+)
+
+# verify things don't crash
+out = m_compiled(x)
+out[0].sum().backward()
+print(fw_cell[0].code)
+print(bw_cell[0].code)


### PR DESCRIPTION
Not for landing


This is just some scratch work I did today trying to get `Float8Tensor` (as a __torch_dispatch__ subclass) to play well with AOTAutograd.

**AOTAutograd bits**

I mostly got things working, with one annoying issue: The custom fp8 linear as written today will return a `Float8Tensor` output in the forward. However, When we call `.sum().backward()`, the sum call returns a plain `torch.Tensor`. This causes the grad_out of the compiled function (in the backward) to be a plain tensor. This is a problem, because:

(1) AOTAutograd eagerly traces out a backward graph to do partitioning, during the forward

(2) it needs to make guesses on whether or not each grad_out will be a subclass

(3) Right now, when it sees a fw_out that is a subclass, it assumes that the corresponding grad_out will also be a subclass

(4) If we guessed wrong, then we'll need to re-trace the backward. This requires backward guards, which are not implemented yet.

I had a workaround hack locally, where I just special-case FP8 in aot autograd to **always** assume that grad_outputs are not subclasses. That seemed to work, and I was able to use `torch.compile` and generate fw and bw graphs.

**Dynamo bits**

However, that isn't enough to test correctness. Why? The custom module in the test has a flag that gets flipped after the first iteration, that dynamo has to specialize the graph on.

I made a mild attempt to get things working in dynamo - seemed to get part of the way through, but eventually I gave up. Some progress here: 814239133