### PR TITLE
fix scaling for float16

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -84,7 +84,8 @@ class float8_linear(torch.autograd.Function):
             go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, 
             is_amax_initialized)
         go_scale = amax_history_to_scale(
-            fp8_amax_history_dL_dY, torch.float8_e5m2, scale_fn_name)
+            fp8_amax_history_dL_dY, torch.float8_e5m2, go.dtype,
+            scale_fn_name)
         go_fp8 = Float8Tensor.to_float8(
             go, go_scale, torch.float8_e5m2, fp8_amax_dL_dY)
         _update_history_with_new_amax(
@@ -178,7 +179,8 @@ class Float8Linear(torch.nn.Linear):
             x, self.fp8_amax_x, self.fp8_amax_history_x, 
             is_amax_initialized_this_iteration)
         x_scale = amax_history_to_scale(
-            self.fp8_amax_history_x, torch.float8_e4m3fn, scale_fn_name)
+            self.fp8_amax_history_x, torch.float8_e4m3fn, x.dtype,
+            scale_fn_name)
         x_fp8 = Float8Tensor.to_float8(
             x, x_scale, torch.float8_e4m3fn, self.fp8_amax_x)
         _update_history_with_new_amax(
@@ -188,7 +190,8 @@ class Float8Linear(torch.nn.Linear):
             self.weight, self.fp8_amax_w, self.fp8_amax_history_w, 
             is_amax_initialized_this_iteration)
         w_scale = amax_history_to_scale(
-            self.fp8_amax_history_w, torch.float8_e4m3fn, scale_fn_name)
+            self.fp8_amax_history_w, torch.float8_e4m3fn, self.weight.dtype,
+            scale_fn_name)
         w_fp8 = Float8Tensor.to_float8(
             self.weight, w_scale, torch.float8_e4m3fn, self.fp8_amax_w)
         _update_history_with_new_amax(

--- a/float8_playground/float8_linear_nots.py
+++ b/float8_playground/float8_linear_nots.py
@@ -126,7 +126,7 @@ class float8_linear_no_tensor_subclass(torch.autograd.Function):
         _maybe_initialize_amaxes_for_float8_cast(
             go, fp8_amax_dL_dY, fp8_amax_history_dL_dY, is_amax_initialized)
         dL_dY_scale = amax_history_to_scale(
-            fp8_amax_history_dL_dY, torch.float8_e5m2,
+            fp8_amax_history_dL_dY, torch.float8_e5m2, go.dtype,
             scale_fn_name)
         fp8_amax_dL_dY.fill_(tensor_to_amax(go))
         go_scaled = go * dL_dY_scale
@@ -195,7 +195,7 @@ class Float8LinearNoTensorSubclass(Float8Linear):
             x, self.fp8_amax_x, self.fp8_amax_history_x,
             is_amax_initialized_this_iteration)
         x_scale = amax_history_to_scale(
-            self.fp8_amax_history_x, torch.float8_e4m3fn,
+            self.fp8_amax_history_x, torch.float8_e4m3fn, x.dtype,
             scale_fn_name)
         x_fp8_d = ToFloat8E4M3FNConstrFuncDecomposed.apply(
             x, x_scale, self.fp8_amax_x)
@@ -206,7 +206,7 @@ class Float8LinearNoTensorSubclass(Float8Linear):
             self.weight, self.fp8_amax_w, self.fp8_amax_history_w,
             is_amax_initialized_this_iteration)
         w_scale = amax_history_to_scale(
-            self.fp8_amax_history_w, torch.float8_e4m3fn,
+            self.fp8_amax_history_w, torch.float8_e4m3fn, self.weight.dtype,
             scale_fn_name)
         w_fp8_d = ToFloat8E4M3FNConstrFuncDecomposed.apply(
             self.weight, w_scale, self.fp8_amax_w)

--- a/tests/test_everything.sh
+++ b/tests/test_everything.sh
@@ -3,8 +3,8 @@
 # terminate script on first error
 set -e
 
-python tests/test.py
-python tests/test_sam.py
+pytest tests/test.py
+pytest tests/test_sam.py
 ./tests/test_fsdp.sh
 
 echo "all tests successful"


### PR DESCRIPTION
Summary:

If computation is happening in `float16`, we need to ensure that the scales are representable in `float16`. Otherwise, we get scales that are infinity which in turn breaks all downstream computation.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: