### PR TITLE
[not for land yet] aot_autograd for Float8Tensor

### DIFF
--- a/float8_playground/float8_tensor.py
+++ b/float8_playground/float8_tensor.py
@@ -99,14 +99,14 @@ class Float8Tensor(torch.Tensor):
         return f"Float8Tensor(dtype={self._data.dtype}, scale={self._scale}, as_orig_prec={self.to_original_precision()}"
 
     def __tensor_flatten__(self):
-        return ("_data",), (self._scale, self._orig_dtype)
+        return ("_data", "_scale"), (self._orig_dtype,)
  
     @staticmethod
     def __tensor_unflatten__(tensors, metadatas):
         return Float8Tensor(
             tensors["_data"],
-            metadatas[0],
-            metadatas[1])
+            tensors["_scale"],
+            metadatas[0],)
 
     def to_original_precision(self):
         return FromFloat8ConstrFunc.apply(self)

--- a/tests/test.py
+++ b/tests/test.py
@@ -156,7 +156,8 @@ class TestFloat8Linear:
 
         m_ref = copy.deepcopy(m)
 
-        m = torch.compile(m, backend=cnt)
+        # m = torch.compile(m, backend=cnt)
+        m = torch.compile(m, backend='aot_eager')
         # verify things don't crash
         y = m(x)
         y.sum().backward()


### PR DESCRIPTION
Summary:

This is an example of how to make Float8Tensor traceable by aot_autograd.

Notes:
1. we need to be on top of PyTorch built with https://github.com/pytorch/pytorch/pull/104483, ETA for this to land is 2023-09-30
2. we need the following local patch to PyTorch to go around the logic which currently assumes that all of a tensor subclass's children have the same symbolic shape: https://www.internalfb.com/intern/paste/P819007767/ . Someone needs to design a better API for specifying this.

Note that dynamo accidentally works without (2) because we don't tell dynamo that `_scale` is a tensor.  However, that doesn't work for aot_autograd.

Test Plan:

```
TORCH_LOGS="+aot" with-proxy pytest tests/test.py -k pt2_ts -s
// we see the forward graph, and there are some graph breaks in the
// backward
```

Reviewers:

Subscribers:

Tasks:

Tags: