### PR TITLE
move amax syncing and history updates out of Float8Linear

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ readiness, backwards compatibility, etc right now is an explicit non-goal at thi
 pip install -r requirements.txt
 ```
 
+# single GPU user API (not final)
+
+```
+from float8_linear import (
+    swap_linear_with_float8_linear,
+    sync_float8_amax_and_scale_history,
+)
+
+# create fp32 model
+m = Model(...)
+
+# convert linears to float8
+swap_linear_with_float8_linear(m)
+
+# training loop
+optimizer.zero_grad()
+# specific to float8: separate step to sync scales/amaxes
+# in the future, this may move to a context manager
+sync_float8_amax_and_scale_history(model)
+# run forward
+y = m(x)
+# run backward
+y.sum().backward()
+# update weights
+optimizer.step()
+```
+
 # high level progress tracking
 
 ## M0: building blocks in core

--- a/float8_playground/float8_linear_utils.py
+++ b/float8_playground/float8_linear_utils.py
@@ -13,7 +13,9 @@ def _maybe_initialize_amaxes_for_float8_cast(x, cur_amax, amax_history, is_initi
     if is_initialized:
         return
     with torch.no_grad():
-        new_amax = tensor_to_amax(x)
+        # Note: we need to enable distributed reduction here in order
+        # to match numerics between single GPU and multi GPU code
+        new_amax = tensor_to_amax(x, distributed_reduction=True)
         cur_amax.fill_(new_amax)
         amax_history[0] = new_amax
 

--- a/float8_playground/float8_utils.py
+++ b/float8_playground/float8_utils.py
@@ -42,14 +42,16 @@ def amax_history_to_scale(
     raise NotImplementedError()
 
 @torch.no_grad()
-def tensor_to_amax(x):
+def tensor_to_amax(x, distributed_reduction=False):
     amax = torch.max(torch.abs(x))
     amax_copy = amax.detach().clone()
-    # Hack: inline the distributed logic, just for testing numerics
-    # with FSDP.
-    # TODO(future): better composability with distributed
-    if dist.is_initialized():
+
+    # If the user asked for distributed reduction, do it.
+    # If the user did not ask for it, assume that it will
+    # happen elsewhere.
+    if distributed_reduction and dist.is_initialized():
         dist.all_reduce(amax, op=dist.ReduceOp.MAX)
+
     return amax
 
 @torch.no_grad()

--- a/tests/test_sam.py
+++ b/tests/test_sam.py
@@ -12,7 +12,10 @@ from transformers import SamModel
 # set up float8 path
 import context
 
-from float8_linear import swap_linear_with_float8_linear
+from float8_linear import (
+    swap_linear_with_float8_linear, 
+    sync_float8_amax_and_scale_history,
+)
 from float8_utils import compute_error
 
 torch.manual_seed(0)
@@ -38,6 +41,7 @@ class TestFloat8SAMIntegrationTest:
         last_hidden_ref = encoder_ref_out.last_hidden_state
         last_hidden_ref.max().backward()
 
+        sync_float8_amax_and_scale_history(encoder_fp8)
         encoder_fp8_out = encoder_fp8(data)
         last_hidden_fp8 = encoder_fp8_out.last_hidden_state
         last_hidden_fp8.max().backward()


### PR DESCRIPTION
Summary:

Adds a model-level function to handle amax syncing across distributed ranks and amax history updates.

This will make it easier to prototype fp8 all-gather for FSDP, and to do the distributed reductions more performantly.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: