### PR TITLE
This change enables the no_ts class to be compiled

### DIFF
--- a/float8_playground/float8_python_api.py
+++ b/float8_playground/float8_python_api.py
@@ -16,9 +16,7 @@ def layout_helper(tensor: torch.Tensor, row_major: bool) -> torch.Tensor:
     if row_major:
         return tensor.contiguous()
     # We need it to be column major
-    if tensor.is_contiguous():
-        return tensor.t().contiguous().t()
-    return tensor
+    return tensor.t().contiguous().t()
 
 
 def addmm_float8_unwrapped(


### PR DESCRIPTION
# Summary

Peeled this off from: https://github.com/pytorch-labs/float8_playground/pull/62

The original path was slightly more optimal for eager code but this is actually more correct.