### PR TITLE
add float8 enabled TP primitives

### DIFF
--- a/float8_playground/tp_linear.py
+++ b/float8_playground/tp_linear.py
@@ -1,0 +1,185 @@
+import torch
+
+from fairscale.nn.model_parallel.layers import (
+    ColumnParallelLinear, 
+    RowParallelLinear,
+)
+
+from fairscale.nn.model_parallel.mappings import (
+    copy_to_model_parallel_region,
+    gather_from_model_parallel_region,
+    scatter_to_model_parallel_region,
+    reduce_from_model_parallel_region,
+)
+
+from float8_linear import Float8LinearMixin, float8_linear
+
+class Float8ColumnParallelLinear(Float8LinearMixin, ColumnParallelLinear):
+    """
+    Same as `ColumnParallelLinear`, but with single GPU compute in float8.
+    """
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type: ignore
+        # Float8 bookkeeping
+        self.float8_pre_forward(input_)
+
+        # forward: no-op
+        #   Float8 comms: no
+        # backward: all-reduce
+        #   Float8 comms: no, because we can't reduce in float8
+        input_parallel = copy_to_model_parallel_region(input_)
+
+        # cast activation and weight to float8
+        input_parallel_fp8 = self.cast_x_to_float8(
+            input_parallel, self.is_amax_initialized)
+        w_fp8 = self.cast_w_to_float8(
+            self.weight, self.is_amax_initialized)
+
+        # Float8: TODO(part 1) move this to float8
+        # Matrix multiply.
+        # output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        bias_none = None
+        output_parallel = self.float8_addmm(
+            input_parallel_fp8, w_fp8, bias_none, self.is_amax_initialized)
+
+        if self.gather_output:
+            # All-gather across the partitions.
+            # forward: gather
+            #   Float8 comms: 
+            #     - in the general case where the next op's input is in high 
+            #       precision, nothing to do.
+            #     - in the special case where the next op's input is in float8
+            #       we could do the comms in float8. TODO(later) implement this
+            #       if it becomes important
+            # backward: split
+            #   Float8 comms - no, split does not do any comms
+            output = gather_from_model_parallel_region(output_parallel)
+        else:
+            # no-op
+            output = output_parallel
+
+        # Float8 bookkeeping
+        self.float8_post_forward()
+        return output
+
+    @classmethod
+    def from_float(cls, mod, emulate=False):
+        # create the new module with a toy size to ensure initialization is fast
+        fake_in_features, fake_out_features = 8, 8
+        new_mod = cls(
+            fake_in_features,
+            fake_out_features)
+        new_mod.in_features = mod.in_features
+        new_mod.out_features = mod.out_features
+        new_mod.weight = mod.weight
+        new_mod.bias = mod.bias
+        new_mod.gather_output = mod.gather_output
+        new_mod.output_size_per_partition = mod.output_size_per_partition
+        new_mod.master_weight = mod.master_weight
+        device_to_use = next(mod.parameters()).device
+        new_mod.to(device_to_use)
+        new_mod.emulate = emulate
+        # TODO: test when creation is on cuda
+        return new_mod
+
+class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
+    """
+    Same as `RowParallelLinear`, but with single GPU compute in float8.
+    """
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type:ignore
+        # Float8 bookkeeping
+        self.float8_pre_forward(input_)
+
+        # Float8: TODO(part 2) do this scatter in float8
+        # Set up backprop all-reduce.
+        if self.input_is_parallel:
+            # no-op
+            input_parallel = input_
+        else:
+            # forward: split
+            #   Float8 comms: none
+            # backward: gather
+            #   Float8 comms: 
+            #     - in the general case where the prev op's grad output is in high 
+            #       precision, nothing to do.
+            #     - in the special case where the prev op's grad output is in float8
+            #       we could do the comms in float8. TODO(later) implement this
+            #       if it becomes important
+            input_parallel = scatter_to_model_parallel_region(input_)
+
+        # cast activation and weight to float8
+        input_parallel_fp8 = self.cast_x_to_float8(
+            input_parallel, self.is_amax_initialized)
+        w_fp8 = self.cast_w_to_float8(
+            self.weight, self.is_amax_initialized)
+
+        # Float8: TODO(part 1) move this to float8
+        # Matrix multiply.
+        # output_parallel = F.linear(input_parallel, self.weight)
+        bias_none = None
+        output_parallel = self.float8_addmm(
+            input_parallel_fp8, w_fp8, bias_none, self.is_amax_initialized)
+
+        # adding zero below is a hack
+        # without this hack, we see the following error: https://gist.github.com/vkuzo/0ed84e35081c8c7d20d0f46ed4322704
+        # pointing to autograd internals: https://fburl.com/code/eiipnnty
+        # it seems like there are some issues within chaining torch.autograd.Function instances
+        # together
+        # TODO(future) figure out a workaround
+        output_parallel = output_parallel + 0.0
+
+        # All-reduce across all the partitions.
+        # forward: reduce
+        #   Float8 comms: none
+        # backward: no-op
+        #   Float8 comms: none
+        output_ = reduce_from_model_parallel_region(output_parallel)
+
+        if self.bias is not None:
+            output = output_ + self.bias
+        else:
+            output = output_
+
+        # Float8 bookkeeping
+        self.float8_post_forward()
+
+        return output
+
+    @classmethod
+    def from_float(cls, mod, emulate=False):
+        # create the new module with a toy size to ensure initialization is fast
+        fake_in_features, fake_out_features = 8, 8
+        new_mod = cls(
+            fake_in_features,
+            fake_out_features)
+        new_mod.in_features = mod.in_features
+        new_mod.out_features = mod.out_features
+        new_mod.weight = mod.weight
+        new_mod.bias = mod.bias
+        new_mod.input_is_parallel = mod.input_is_parallel
+        new_mod.input_size_per_partition = mod.input_size_per_partition
+        new_mod.master_weight = mod.master_weight
+        # TODO: test when creation is on cuda
+        device_to_use = next(mod.parameters()).device
+        new_mod.to(device_to_use)
+        new_mod.emulate = emulate
+        return new_mod
+
+def swap_tp_linear_with_float8_linear(model, emulate=False):
+    """
+    Replaces all instances of {Column|Row}ParallelLinear in the given model
+    with their Float8 enabled versions.
+
+    Args:
+        model (torch.nn.Module): The model to modify.
+        emulate (bool, optional): Whether to emulate the fp8 matmul logic in float32.
+    """
+    name_to_child = dict(model.named_children())
+    for name, child in name_to_child.items():
+        if isinstance(child, ColumnParallelLinear):
+            new_child = Float8ColumnParallelLinear.from_float(child, emulate)
+            setattr(model, name, new_child)
+        elif isinstance(child, RowParallelLinear):
+            new_child = Float8RowParallelLinear.from_float(child, emulate)
+            setattr(model, name, new_child)
+        else:
+            swap_tp_linear_with_float8_linear(child, emulate)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.4.0
 transformers==4.32.0
 fire==0.5.0
+fairscale

--- a/tests/test_everything.sh
+++ b/tests/test_everything.sh
@@ -6,5 +6,6 @@ set -e
 pytest tests/test.py
 pytest tests/test_sam.py
 ./tests/test_fsdp.sh
+./tests/test_tp.sh
 
 echo "all tests successful"

--- a/tests/test_tp.py
+++ b/tests/test_tp.py
@@ -1,0 +1,118 @@
+"""
+Test numerics of manually defined float16 TP vs float8 TP of toy models
+"""
+
+import copy
+import os
+
+import torch
+import torch.nn as nn
+
+from fairscale.nn.model_parallel.layers import (
+    ColumnParallelLinear, 
+    RowParallelLinear,
+)
+from fairscale.nn.model_parallel.initialize import initialize_model_parallel
+
+# set up float8 path
+import context
+
+from tp_linear import (
+    swap_tp_linear_with_float8_linear,
+)
+
+from float8_utils import (
+    compute_error,
+)
+
+# copied from https://github.com/facebookresearch/llama/blob/main/example.py
+def setup_model_parallel():
+    local_rank = int(os.environ.get("LOCAL_RANK", -1))
+    world_size = int(os.environ.get("WORLD_SIZE", -1))
+
+    torch.distributed.init_process_group("nccl")
+    initialize_model_parallel(world_size)
+    torch.cuda.set_device(local_rank)
+
+    # seed must be the same in all processes
+    torch.manual_seed(1)
+    return local_rank, world_size
+
+def test_column_parallel_linear():
+    M, K, N = 128, 64, 256
+    m_ref = nn.Sequential(ColumnParallelLinear(K, N)).cuda()
+    m = copy.deepcopy(m_ref)
+    swap_tp_linear_with_float8_linear(m)
+
+    x = torch.randn(M, K, device='cuda')
+    y_ref = m_ref(x)
+    y = m(x)
+
+    y_ref.sum().backward()
+    y.sum().backward()
+
+    sqnr_y = compute_error(y_ref, y)
+    sqnr_w_grad = compute_error(m_ref[0].weight.grad, m[0].weight.grad)
+
+    assert sqnr_y >= 20.0, f'sqnr_y {sqnr_y} is too low'
+    assert sqnr_w_grad >= 20.0, f'sqnr_w_grad {sqnr_w_grad} is too low'
+
+def test_row_parallel_linear():
+    M, K, N = 128, 64, 256
+    m_ref = nn.Sequential(RowParallelLinear(K, N)).cuda()
+    m = copy.deepcopy(m_ref)
+    swap_tp_linear_with_float8_linear(m)
+
+    x = torch.randn(M, K, device='cuda')
+    y_ref = m_ref(x)
+    y = m(x)
+
+    y_ref.sum().backward()
+    y.sum().backward()
+
+    sqnr_y = compute_error(y_ref, y)
+    sqnr_w_grad = compute_error(m_ref[0].weight.grad, m[0].weight.grad)
+
+    assert sqnr_y >= 20.0, f'sqnr_y {sqnr_y} is too low'
+    assert sqnr_w_grad >= 20.0, f'sqnr_w_grad {sqnr_w_grad} is too low'
+
+class FFN(nn.Module):
+    def __init__(self, dim, hidden_dim):
+        super().__init__()
+        self.w1 = ColumnParallelLinear(dim, hidden_dim, bias=False)
+        self.act = nn.ReLU()
+        self.w2 = RowParallelLinear(hidden_dim, dim, bias=False)
+
+    def forward(self, x):
+        x = self.w1(x)
+        x = self.act(x)
+        x = self.w2(x)
+        return x
+
+def test_ffn():
+    M, dim, hidden_dim = 32, 32, 64
+    m_ref = FFN(dim, hidden_dim).cuda()
+    m = copy.deepcopy(m_ref)
+    swap_tp_linear_with_float8_linear(m)
+
+    x = torch.randn(M, dim, device='cuda')
+    y_ref = m_ref(x)
+    y = m(x)
+
+    y_ref.sum().backward()
+    y.sum().backward()
+
+    sqnr_y = compute_error(y_ref, y)
+    sqnr_w1_grad = compute_error(m_ref.w1.weight.grad, m.w1.weight.grad)
+    sqnr_w2_grad = compute_error(m_ref.w2.weight.grad, m.w2.weight.grad)
+
+    assert sqnr_y >= 20.0, f'sqnr_y {sqnr_y} is too low'
+    assert sqnr_w1_grad >= 14.0, f'sqnr_w1_grad {sqnr_w1_grad} is too low'
+    assert sqnr_w2_grad >= 30.0, f'sqnr_w2_grad {sqnr_w2_grad} is too low'
+    
+
+if __name__ == '__main__':
+    local_rank, world_size = setup_model_parallel()
+    test_column_parallel_linear()
+    test_row_parallel_linear()
+    test_ffn()

--- a/tests/test_tp.sh
+++ b/tests/test_tp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# terminate script on first error
+set -e
+
+NCCL_DEBUG=WARN torchrun --nproc_per_node 2 tests/test_tp.py


### PR DESCRIPTION
Summary:

Adds tensor parallelism primitives with float8 enabled.  Uses the Fairscale version as a reference.

A future PR will add sequence parallel support.

Test Plan:

```
// now includes toy layer tests for TP
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: