### PR TITLE
add SP support to {Column|Row}Float8Linear, comms in fp16

### DIFF
--- a/float8_playground/distributed_utils.py
+++ b/float8_playground/distributed_utils.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+import torch
+
+from fairscale.nn.model_parallel.initialize import get_model_parallel_group
+
+# additional differentiable distributed primitives for SP which are not in
+# the Fairscale codebase
+
+def _gather_along_first_dim(input_: torch.Tensor):
+    # same as https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/model_parallel/mappings.py#L67, 
+    # but gather along first dim instead of last dim
+    group = get_model_parallel_group()
+
+    # Bypass the function if we are using only 1 GPU.
+    if torch.distributed.get_world_size(group=group) == 1:
+        return input_
+
+    # Size and dimension.
+    first_dim = 0
+    rank = torch.distributed.get_rank(group=group)
+    world_size = torch.distributed.get_world_size(group=group)
+
+    # tensors must be contiguous for all_gather to work
+    input_contig = input_.contiguous()
+
+    tensor_list = [torch.empty_like(input_contig) for _ in range(world_size)]
+    tensor_list[rank] = input_contig
+    torch.distributed.all_gather(tensor_list, input_contig, group=group)
+
+    # Note: torch.cat already creates a contiguous tensor.
+    output = torch.cat(tensor_list, dim=first_dim).contiguous()
+
+    return output
+
+def _reduce_scatter(ctx: Any, input_: torch.Tensor):
+    group = get_model_parallel_group()
+    rank = torch.distributed.get_rank(group)
+    world_size = torch.distributed.get_world_size(group)
+
+    assert input_.shape[0] % world_size == 0
+    output_shape = (input_.shape[0] // world_size, *input_.shape[1:])
+    output = torch.empty(*output_shape, device=input_.device, dtype=input_.dtype)
+
+    torch.distributed.reduce_scatter_tensor(output, input_, group=group)
+    return output
+
+def _split_along_first_dim(input_: torch.Tensor):
+    # this is needed for testing
+
+    # like fairscale.nn.model_parallel.mappings._split, but
+    # along the first dim instead of last dim
+
+    group = get_model_parallel_group()
+    local_rank = torch.distributed.get_rank(group)
+    world_size = torch.distributed.get_world_size(group)
+
+    assert input_.shape[0] % world_size == 0
+    input_list = torch.split(input_, input_.shape[0] // world_size)
+    return input_list[local_rank]
+    
+    
+
+class _AllGatherFwReduceScatterBw(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_):
+        return _gather_along_first_dim(input_)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return _reduce_scatter(ctx, grad_output)
+
+class _ReduceScatterFwAllGatherBw(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_):
+        return _reduce_scatter(ctx, input_)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return _gather_along_first_dim(grad_output)
+
+class _AllGatherFwSplitBw(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_):
+        return _gather_along_first_dim(input_)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return _split_along_first_dim(grad_output)

--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -176,6 +176,10 @@ class Float8LinearMixin(object):
         # update function
         self.last_seen_input_dtype = None
 
+        # If true, this enables TP+SP style distributed comms in TP primitives
+        # Note: this is not used in non-TP code.
+        self.use_sequence_parallel = False
+
     def cast_x_to_float8(self, x, is_amax_initialized):
         # Duplicate the autocast logic for F.linear, so that the output
         # of our module has the right original precision

--- a/tests/test_tp.py
+++ b/tests/test_tp.py
@@ -25,6 +25,10 @@ from float8_utils import (
     compute_error,
 )
 
+from distributed_utils import (
+    _AllGatherFwSplitBw,    
+)
+
 # copied from https://github.com/facebookresearch/llama/blob/main/example.py
 def setup_model_parallel():
     local_rank = int(os.environ.get("LOCAL_RANK", -1))
@@ -79,9 +83,9 @@ def test_row_parallel_linear():
 class FFN(nn.Module):
     def __init__(self, dim, hidden_dim):
         super().__init__()
-        self.w1 = ColumnParallelLinear(dim, hidden_dim, bias=False)
+        self.w1 = ColumnParallelLinear(dim, hidden_dim, bias=False, gather_output=False)
         self.act = nn.ReLU()
-        self.w2 = RowParallelLinear(hidden_dim, dim, bias=False)
+        self.w2 = RowParallelLinear(hidden_dim, dim, bias=False, input_is_parallel=True)
 
     def forward(self, x):
         x = self.w1(x)
@@ -109,6 +113,41 @@ def test_ffn():
     assert sqnr_y >= 20.0, f'sqnr_y {sqnr_y} is too low'
     assert sqnr_w1_grad >= 14.0, f'sqnr_w1_grad {sqnr_w1_grad} is too low'
     assert sqnr_w2_grad >= 30.0, f'sqnr_w2_grad {sqnr_w2_grad} is too low'
+
+
+def test_ffn_sp(local_rank, world_size):
+    # for this test:
+    # baseline: float8 FFN with TP but no SP
+    # experiment: float8 FFN with TP and SP
+    # we expect the numerics to match exactly
+
+    M, dim, hidden_dim = 32, 32, 64
+    m_ref = FFN(dim, hidden_dim).cuda()
+    swap_tp_linear_with_float8_linear(m_ref)
+
+    m = copy.deepcopy(m_ref)
+    # TODO(future): nicer API for setting this
+    m.w1.use_sequence_parallel = True
+    m.w2.use_sequence_parallel = True
+
+    x_ref = torch.randn(M, dim, device='cuda')
+    y_ref = m_ref(x_ref)
+    y_ref.sum().backward()
+
+    # for SP, we need to split the input before passing it to the module
+    # TODO(before land): just use scatter
+    # TODO(before land): can use _split_along_first_dim
+    assert x_ref.shape[0] % world_size == 0
+    x_list = torch.split(x_ref, x_ref.shape[0] // world_size)
+    x = x_list[local_rank]
+     
+    y_local = m(x)
+    y_gathered = _AllGatherFwSplitBw.apply(y_local)
+    y_gathered.sum().backward()
+
+    torch.testing.assert_close(y_ref, y_gathered)
+    torch.testing.assert_close(m_ref.w1.weight.grad, m.w1.weight.grad)
+    torch.testing.assert_close(m_ref.w2.weight.grad, m.w2.weight.grad)
     
 
 if __name__ == '__main__':
@@ -116,3 +155,4 @@ if __name__ == '__main__':
     test_column_parallel_linear()
     test_row_parallel_linear()
     test_ffn()
+    test_ffn_sp(local_rank, world_size)


### PR DESCRIPTION
Summary:

Adds SP support and a unit test to verify numerics with SP match numerics without SP exactly.

For now distributed comms stay in fp16, a future PR will enable fp8 comms for SP.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: