### PR TITLE
remove float8 addmm and do bias addition outside of cuBlasLt

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -29,26 +29,6 @@ def mm_float8_emulated(
     return m3_fp32.to(dtype3), tensor_to_amax(m3_fp32)
 
 
-# TODO naming of these vars is weird
-def addmm_float8_emulated(
-    inp1,  # bias (in fp32/fp16/bf16, no fp8 support)
-    m1,  # input 1 data
-    s1,  # input 1 scale
-    m2,  # input 2 data
-    s2,  # input 2 scale
-    s3,  # output scale
-    dtype3,  # output dtype
-):
-    # naive implementation: dq -> op -> q
-    # TODO(future): hook up to real kernel
-    m1_fp32 = m1.float() / s1
-    m2_fp32 = m2.float() / s2
-    inp1 = inp1.float()
-    m3_fp32 = torch.addmm(inp1, m1_fp32, m2_fp32)
-
-    return m3_fp32.to(dtype3), tensor_to_amax(m3_fp32)
-
-
 #
 # ATen op placeholders
 #
@@ -60,7 +40,3 @@ lib = Library("aten", "FRAGMENT")
 lib.define("mm_float8_emulated(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3, ScalarType dtype3) -> (Tensor, Tensor)")
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CPU")
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CUDA")
-
-lib.define("addmm_float8_emulated(Tensor inp1, Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3, ScalarType dtype3) -> (Tensor, Tensor)")
-lib.impl("addmm_float8_emulated", addmm_float8_emulated, "CPU")
-lib.impl("addmm_float8_emulated", addmm_float8_emulated, "CUDA")


### PR DESCRIPTION
Summary:

Removing the fused `addmm` functionality for now to simplify the code. There are a couple of reasons why this is useful:
1. the cuBlasLt op does not support float32 bias, if we don't pass bias into this op we don't need to care about this restriction
2. for sequence_parallel support, it's useful to move the cast of the dL_dY tensor into float8 outside of `float8_linear`. However, this doesn't work well if bias addition is handled inside of `float8_linear`.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: