### PR TITLE
move dL_dY cast out of float8_linear

### DIFF
--- a/float8_playground/float8_tensor.py
+++ b/float8_playground/float8_tensor.py
@@ -75,8 +75,6 @@ class Float8Tensor(torch.Tensor):
     """
 
     def __new__(cls, data: torch.Tensor, scale: torch.Tensor, orig_dtype: torch.dtype):
-        # This is a non-differentiable constructor!
-        assert not data.requires_grad
         assert scale.nelement() == 1
 
         self = torch.Tensor._make_wrapper_subclass(
@@ -147,7 +145,7 @@ class Float8Tensor(torch.Tensor):
                 args[0]._data.as_strided(*args[1:], **kwargs), args[0]._scale, 
                 args[0]._orig_dtype)
         
-        raise NotImplementedError()
+        raise NotImplementedError(f'attempting to run {func}, this is not supported')
 
     # Do not force the Float8Tensor type on the returned tensor
     __torch_function__ = torch._C._disabled_torch_function_impl

--- a/float8_playground/tp_linear.py
+++ b/float8_playground/tp_linear.py
@@ -53,6 +53,7 @@ class Float8ColumnParallelLinear(Float8LinearMixin, ColumnParallelLinear):
         # Matrix multiply.
         output_parallel = self.float8_mm(
             input_parallel_fp8, w_fp8, self.is_amax_initialized)
+        output_parallel = self.cast_y_to_float8_in_bw(output_parallel)
 
         if self.bias is not None:
             output_parallel = output_parallel + self.bias.to(output_parallel.dtype)
@@ -134,6 +135,7 @@ class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
         # output_parallel = F.linear(input_parallel, self.weight)
         output_parallel = self.float8_mm(
             input_parallel_fp8, w_fp8, self.is_amax_initialized)
+        output_parallel = self.cast_y_to_float8_in_bw(output_parallel)
 
         # adding zero below is a hack
         # without this hack, we see the following error: https://gist.github.com/vkuzo/0ed84e35081c8c7d20d0f46ed4322704


### PR DESCRIPTION
Summary:

This is needed for upcoming SP support of doing
distributed comms for a gather in the backward in float8.

Test Plan:

```
with-proxy ./tests/test_tp.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: