### PR TITLE
remove unused output scale arguments

### DIFF
--- a/float8_playground/float8_aten_api.py
+++ b/float8_playground/float8_aten_api.py
@@ -18,7 +18,6 @@ def mm_float8_emulated(
     s1,  # input 1 scale
     m2,  # input 2 data
     s2,  # input 2 scale
-    s3,  # output scale
     dtype3,  # output dtype
 ):
     # naive implementation: dq -> op -> q
@@ -37,6 +36,6 @@ def mm_float8_emulated(
 # These are mostly placeholder and might need to be implemented in c++ as needed
 lib = Library("aten", "FRAGMENT")
 
-lib.define("mm_float8_emulated(Tensor m1, Tensor s1, Tensor m2, Tensor s2, Tensor s3, ScalarType dtype3) -> (Tensor, Tensor)")
+lib.define("mm_float8_emulated(Tensor m1, Tensor s1, Tensor m2, Tensor s2, ScalarType dtype3) -> (Tensor, Tensor)")
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CPU")
 lib.impl("mm_float8_emulated", mm_float8_emulated, "CUDA")

--- a/tests/test.py
+++ b/tests/test.py
@@ -230,11 +230,8 @@ class TestScaledMM:
         a_fp8 = Float8Tensor.to_float8(a, a_scale, input_dtype)
         b_fp8 = Float8Tensor.to_float8(b, b_scale, input_dtype)
 
-        output_scaled_scale = torch.tensor(1.0, device='cuda')
-        output_emulated_scale = torch.tensor(1.0, device='cuda')
-
-        out_scaled_mm, output_amax_scaled = mm_float8(a_fp8, b_fp8, output_scale=output_scaled_scale, output_dtype=output_dtype, emulate=False)
-        out_emulated, output_amax_emulated = mm_float8(a_fp8, b_fp8, output_scale=output_emulated_scale, output_dtype=output_dtype, emulate=True)
+        out_scaled_mm, output_amax_scaled = mm_float8(a_fp8, b_fp8, output_dtype=output_dtype, emulate=False)
+        out_emulated, output_amax_emulated = mm_float8(a_fp8, b_fp8, output_dtype=output_dtype, emulate=True)
 
         if output_dtype != base_dtype:
             out_scaled_mm = out_scaled_mm.to(compare_type)


### PR DESCRIPTION
Summary:

Since we are not returning float8 from our matmul, we don't need to care about output amaxes or scales.  This PR removes the args/buffers used for handling this feature to simplify the code.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: