### PR TITLE
make memory layout conversions explicit

### DIFF
--- a/float8_playground/float8_linear.py
+++ b/float8_playground/float8_linear.py
@@ -108,24 +108,32 @@ class float8_linear(torch.autograd.Function):
             go_fp8._data.reshape(-1, go_fp8_orig_shape[-1]), go_fp8._scale, 
             go_fp8._orig_dtype)
 
+        w_fp8_t_c_t = Float8Tensor(
+            w_fp8._data.t().contiguous().t(),
+            w_fp8._scale, w_fp8._orig_dtype)
+
         #
         # calculate dL/dX
         #
         dL_dX, _dL_dX_amax = mm_float8(
-            go_fp8_reshaped, w_fp8, output_dtype=x_fp8._orig_dtype, 
+            go_fp8_reshaped, w_fp8_t_c_t, output_dtype=x_fp8._orig_dtype, 
             emulate=emulate)
         dL_dX = dL_dX.reshape(*go_fp8_orig_shape[:-1], dL_dX.shape[-1])
 
         x_fp8_orig_shape = x_fp8._data.shape
-        x_fp8_reshaped_t = Float8Tensor(
-            x_fp8._data.reshape(-1, x_fp8_orig_shape[-1]).t(), x_fp8._scale,
+        x_fp8_reshaped_t_c = Float8Tensor(
+            x_fp8._data.reshape(-1, x_fp8_orig_shape[-1]).t().contiguous(), x_fp8._scale,
             x_fp8._orig_dtype)
+
+        go_fp8_reshaped_t_c_t = Float8Tensor(
+            go_fp8_reshaped._data.t().contiguous().t(), go_fp8_reshaped._scale, 
+            go_fp8_reshaped._orig_dtype)
 
         #
         # calculate dL/dW
         #
         dL_dW, _dL_dW_amax = mm_float8(
-            x_fp8_reshaped_t, go_fp8_reshaped, output_dtype=x_fp8._orig_dtype, 
+            x_fp8_reshaped_t_c, go_fp8_reshaped_t_c_t, output_dtype=x_fp8._orig_dtype, 
             emulate=emulate)
         dL_dW = dL_dW.t()
 

--- a/float8_playground/float8_linear_nots.py
+++ b/float8_playground/float8_linear_nots.py
@@ -122,7 +122,7 @@ class float8_linear_no_tensor_subclass(torch.autograd.Function):
         else:
             dL_dX_bits, _dL_dX_amax = mm_float8_unwrapped(
                 go_fp8_reshaped, fp8_scale_dL_dY,
-                w_fp8_d, w_fp8_scale, output_dtype, output_scale=None)
+                w_fp8_d.t().contiguous().t(), w_fp8_scale, output_dtype, output_scale=None)
         dL_dX_bits = dL_dX_bits.reshape(*go_fp8_orig_shape[:-1], dL_dX_bits.shape[-1])
 
         x_fp8_orig_shape = x_fp8_d.shape
@@ -138,8 +138,8 @@ class float8_linear_no_tensor_subclass(torch.autograd.Function):
             dL_dW_bits = dL_dW_bits.t()
         else:
             dL_dW_bits, _dL_dW_amax = mm_float8_unwrapped(
-                x_fp8_reshaped.t(), x_fp8_scale,
-                go_fp8_reshaped, fp8_scale_dL_dY,
+                x_fp8_reshaped.t().contiguous(), x_fp8_scale,
+                go_fp8_reshaped.t().contiguous().t(), fp8_scale_dL_dY,
                 output_dtype, output_scale=None)
             dL_dW_bits = dL_dW_bits.t()
         empty_grads = None, None, None, None, None, None, None, None, None, None, None, None

--- a/float8_playground/float8_python_api.py
+++ b/float8_playground/float8_python_api.py
@@ -10,15 +10,6 @@ import float8_aten_api
 import warnings
 from typing import Optional, Tuple
 
-def layout_helper(tensor: torch.Tensor, row_major: bool) -> torch.Tensor:
-    """ Cublas requires row_major @ column major tensors"""
-    # TODO Figure out a better way of checking for correct layout
-    if row_major:
-        return tensor.contiguous()
-    # We need it to be column major
-    return tensor.t().contiguous().t()
-
-
 def mm_float8_unwrapped(
         a_data: torch.Tensor,
         a_scale: torch.Tensor,
@@ -30,14 +21,12 @@ def mm_float8_unwrapped(
         as inputs. This is used to standardize the logic between subclassed and non subclassed
         versions of the linear module.
     """
-    temp_a = layout_helper(a_data, row_major=True)
-    temp_b = layout_helper(b_data, row_major=False)
 
     a_inverse_scale = 1 / a_scale
     b_inverse_scale = 1 / b_scale
     output, output_amax = torch._scaled_mm(
-        temp_a,
-        temp_b,
+        a_data,
+        b_data,
         bias=None,
         out_dtype=output_dtype,
         scale_a=a_inverse_scale,


### PR DESCRIPTION
Summary:

The UX of doing the layout conversions out the hood is nice, but removing the magic handling for now and spelling these out explicitly to make it clearer from the code where expensive things are happening.

IMO this will make it easier to reason about how to speed up our code as we won't have to rely on traces to understand where the contiguous calls are.

Test Plan:

```
with-proxy ./tests/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: