### PR TITLE
fix output dtype of nots branch

### DIFF
--- a/float8_playground/float8_linear_nots.py
+++ b/float8_playground/float8_linear_nots.py
@@ -32,6 +32,7 @@ class ToFloat8E4M3FNConstrFuncDecomposed(torch.autograd.Function):
         scale: float=None,
         amax_buffer=None,
     ):
+        ctx.orig_dtype = tensor.dtype
         # In TransformerEngine, the casts to float8 are fused with calculating
         # the new amax value. In this codebase, the eager mode code for those
         # two things is colocated in this function. We expect PT2.0 to fuse it
@@ -45,7 +46,8 @@ class ToFloat8E4M3FNConstrFuncDecomposed(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, g):
-        return g.to(torch.float32), None, None, None
+        g = g.to(ctx.orig_dtype)
+        return g, None, None, None
 
 
 class float8_linear_no_tensor_subclass(torch.autograd.Function):


### PR DESCRIPTION
Summary:

Removes an unneeded cast to fp32 from the nots codebase, this removes a memory read/write from the backward

Test Plan:

```
> python benchmarks/bench_linear_float8_nots.py -n 1 -o ../tmp/test.txt

// before: 0.0059 sec, 0.373 speedup
// after: 0.0053 sec, 0.412 speedup
// full logs: https://gist.github.com/vkuzo/22df8ac7d3e6b6623a9ab3fff1b723d6
```

Reviewers:

Subscribers:

Tasks:

Tags: