### PR TITLE
make benchmarking script output nicer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "fire==0.5.0",
     "fairscale==0.4.13",
     "tqdm==4.66.1",
+    "pandas >= 2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Summary:

Test Plan:

```
// just the cuBLASLt op
> python ./benchmarks/bench_matmul.py
        name                shape           dtype  ref_time_s  fp8_time_s  fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16    0.000622    0.000244     2.544207
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16    0.000499    0.000257     1.940545
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16    0.003445    0.001470     2.343664
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16    0.001628    0.000700     2.324733
4  attn.wqkv  (16384, 8192, 1280)   torch.float16    0.000588    0.000236     2.494773
5    attn.w0  (16384, 1024, 8192)   torch.float16    0.000569    0.000250     2.276295
6    ffn.w13  (16384, 8192, 7168)   torch.float16    0.003900    0.001471     2.650652
7     ffn.w2  (16384, 3584, 8192)   torch.float16    0.001922    0.000778     2.471631

// linear fw + bw (3 matmuls + scaled cast of all args)
> python ./benchmarks/bench_linear_float8_nots.py --compile -o ../tmp/float8_perf_20230918.csv
        name                shape       ref_dtype  compiled  ref_time_sec  pt_fp8_time_sec  te_fp8_time_sec  pt_fp8_speedup  te_fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16      True      0.002113         0.003604         0.001955        0.586272        1.080678
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16      True      0.001888         0.003227         0.001678        0.584983        1.125223
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16      True      0.009910         0.009269         0.006331        1.069068        1.565369
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16      True      0.005209         0.005576         0.003626        0.934252        1.436472
4  attn.wqkv  (16384, 8192, 1280)   torch.float16      True      0.002244         0.003637         0.001901        0.616992        1.180696
5    attn.w0  (16384, 1024, 8192)   torch.float16      True      0.001925         0.003149         0.001617        0.611443        1.190894
6    ffn.w13  (16384, 8192, 7168)   torch.float16      True      0.010279         0.009236         0.006415        1.112844        1.602223
7     ffn.w2  (16384, 3584, 8192)   torch.float16      True      0.005537         0.005499         0.003573        1.006778        1.549667
```

Reviewers:

Subscribers:

Tasks:

Tags: