### PR TITLE
[not for land yet] test perf with TE's amax-cast-transpose-cont kernel

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -159,15 +159,15 @@ class Float8LinearMixin(object):
         self.recipe = delayed_scaling_recipe
         history_len = self.recipe.history_len
 
-        self.register_buffer('fp8_amax_x', torch.tensor(E4M3_MAX_POS))
-        self.register_buffer('fp8_amax_history_x', torch.zeros(history_len))
-        self.register_buffer('fp8_scale_x', torch.tensor(1.0))
-        self.register_buffer('fp8_amax_w', torch.tensor(E4M3_MAX_POS))
-        self.register_buffer('fp8_amax_history_w', torch.zeros(history_len))
-        self.register_buffer('fp8_scale_w', torch.tensor(1.0))
-        self.register_buffer('fp8_amax_dL_dY', torch.tensor(E5M2_MAX_POS))
-        self.register_buffer('fp8_amax_history_dL_dY', torch.zeros(history_len))
-        self.register_buffer('fp8_scale_dL_dY', torch.tensor(1.0))
+        self.register_buffer('fp8_amax_x', torch.tensor([E4M3_MAX_POS]))
+        self.register_buffer('fp8_amax_history_x', torch.zeros(history_len, 1))
+        self.register_buffer('fp8_scale_x', torch.tensor([1.0]))
+        self.register_buffer('fp8_amax_w', torch.tensor([E4M3_MAX_POS]))
+        self.register_buffer('fp8_amax_history_w', torch.zeros(history_len, 1))
+        self.register_buffer('fp8_scale_w', torch.tensor([1.0]))
+        self.register_buffer('fp8_amax_dL_dY', torch.tensor([E5M2_MAX_POS]))
+        self.register_buffer('fp8_amax_history_dL_dY', torch.zeros(history_len, 1))
+        self.register_buffer('fp8_scale_dL_dY', torch.tensor([1.0]))
         # Whether to emulate the fp8 matmul logic in float32
         self.emulate = False
 

--- a/float8_experimental/te_utils.py
+++ b/float8_experimental/te_utils.py
@@ -1,0 +1,69 @@
+"""
+Temporary wrapper of parts of TransformerEngine, to test performance
+with TE kernels
+"""
+
+import torch
+
+from float8_experimental.float8_utils import (
+    tensor_to_amax,
+    to_fp8_saturated,
+)
+
+# TODO guard against TE not available
+# import transformer_engine as te
+import transformer_engine.pytorch.cpp_extensions as tex
+
+def te_fp8_cast_transpose_fused(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    amax_history: torch.Tensor,
+    amax: torch.Tensor,
+    out_dtype: torch.dtype,  # float8_e4m3fn or float8_e5m2
+):
+    fp8_meta_tensor = tex.FP8TensorMeta()
+    # reference: https://github.com/NVIDIA/TransformerEngine/blob/eb64ec2a26b1091a78af424deb7d5204bee17cd2/transformer_engine/pytorch/module/base.py#L291
+    fp8_meta_tensor.scale = scale
+    fp8_meta_tensor.amax_history = amax_history
+
+    # The TE kernel requires scale_inv, but the PyTorch codebase currently
+    # does not have this. For now, create it inline. This will be a performance
+    # regression against TE.
+    # TODO(future): guard against division by zero
+    fp8_meta_tensor.scale_inv = 1.0 / scale
+
+    # this is just used for the index of scale/amax_history/scale_inv tensors
+    # reference: https://github.com/NVIDIA/TransformerEngine/blob/eb64ec2a26b1091a78af424deb7d5204bee17cd2/transformer_engine/pytorch/cpp_extensions/transpose.py#L36
+    fp8_tensor = tex.FP8FwdTensors.GEMM1_INPUT
+
+    otype = tex.DType.kFloat8E4M3 if out_dtype is torch.float8_e4m3fn \
+        else tex.DType.kFloat8E5M2
+    
+    # y_t_c means y_transpose_contiguous
+    y, y_t_c = tex.fp8_cast_transpose_fused(
+        x,
+        fp8_meta_tensor,
+        fp8_tensor,
+        otype,
+    )
+
+    # The TE kernel does not update amax, but the PyTorch codebase currently
+    # uses a separate buffer for amax. For now, update it manually.
+    # This will be a performance regression against TE.
+    amax.copy_(amax_history[0])
+
+    return y.view(out_dtype), y_t_c.view(out_dtype)
+
+def pt_fp8_cast_transpose(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    amax_history: torch.Tensor,
+    amax: torch.Tensor,
+    out_dtype: torch.dtype,  # float8_e4m3fn or float8_e5m2
+):
+    new_amax = tensor_to_amax(x)
+    amax.copy_(new_amax)
+    x_scaled = x * scale
+    y = to_fp8_saturated(x_scaled, out_dtype)
+    y_t_c = y.t().contiguous()
+    return y, y_t_c


### PR DESCRIPTION
Summary:

This uses TransformerEngine's amax-cast-transpose-contiguous kernel from inside of our no-tensor-subclass branch, instead of using individual PyTorch kernels for the equivalent operation.

Performance in eager mode for our single linear fw-bw benchmark is on par/slightly better than TE after this PR. More study is necessary to validate on e2e models.

torch.compile doesn't work with this PR as is, there might be a way to hack it. Leaving that for the future.

Note that numerics are close to before this PR but the history calculation is not correct as is, because the TE kernel updates the history and our code assumes the history update happens in the history update function. We could refactor our code to defer the history update to the kernel if needed to get correct numerics back, but leaving that out for now since we just want to get a perf baseline.

TBD if we land this, but putting it up for discussion.

Test Plan:

```
// numerics are good, with the exception of the history issue described above
pytest tests/test.py -s

// before this PR
> python ./benchmarks/bench_linear_float8_nots.py -o ../tmp/float8_perf_20230918.csv
        name                shape       ref_dtype  compiled  ref_time_sec  pt_fp8_time_sec  te_fp8_time_sec  pt_fp8_speedup  te_fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16     False      0.002061         0.004275         0.001913        0.482127        1.077659
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16     False      0.001798         0.003764         0.001686        0.477703        1.066519
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16     False      0.010012         0.010947         0.006339        0.914650        1.579396
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16     False      0.005453         0.006714         0.003647        0.812249        1.495317
4  attn.wqkv  (16384, 8192, 1280)   torch.float16     False      0.002235         0.004299         0.001961        0.519846        1.139663
5    attn.w0  (16384, 1024, 8192)   torch.float16     False      0.001852         0.003770         0.001631        0.491125        1.135182
6    ffn.w13  (16384, 8192, 7168)   torch.float16     False      0.010180         0.010949         0.006506        0.929722        1.564646
7     ffn.w2  (16384, 3584, 8192)   torch.float16     False      0.005883         0.006727         0.003579        0.874513        1.643654

// after this PR
> python ./benchmarks/bench_linear_float8_nots.py -o ../tmp/float8_perf_20230918.csv
        name                shape       ref_dtype  compiled  ref_time_sec  pt_fp8_time_sec  te_fp8_time_sec  pt_fp8_speedup  te_fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16     False      0.002056         0.001820         0.001912        1.129804        1.075357
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16     False      0.001798         0.001594         0.001644        1.128419        1.094035
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16     False      0.010004         0.006586         0.006307        1.519072        1.586163
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16     False      0.005434         0.003654         0.003591        1.487089        1.513293
4  attn.wqkv  (16384, 8192, 1280)   torch.float16     False      0.002194         0.001829         0.001966        1.199517        1.115886
5    attn.w0  (16384, 1024, 8192)   torch.float16     False      0.001851         0.001579         0.001681        1.171625        1.100746
6    ffn.w13  (16384, 8192, 7168)   torch.float16     False      0.010248         0.006567         0.006567        1.560686        1.560480
7     ffn.w2  (16384, 3584, 8192)   torch.float16     False      0.005541         0.003785         0.003645        1.463700        1.520210
```

Reviewers:

Subscribers:

Tasks:

Tags: