### PR TITLE
Pass around a config that can be used for mutating what _scaled_mm's behavior

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -15,7 +15,7 @@ from float8_experimental.float8_linear_utils import (
     _maybe_initialize_amaxes_scales_for_float8_cast,
 )
 
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
 
 from float8_experimental.float8_utils import (
     E4M3_MAX_POS,
@@ -40,12 +40,12 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
         fp8_scale_dL_dY,
         scale_fn_name,
         is_amax_initialized,
-        emulate: bool,
+        mm_config: ScaledMMConfig,
     ):
         ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY, fp8_scale_dL_dY)
         ctx.scale_fn_name = scale_fn_name
         ctx.is_amax_initialized = is_amax_initialized
-        ctx.emulate = emulate
+        ctx.mm_config = mm_config
         return tensor
 
     @staticmethod
@@ -68,7 +68,7 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
         go_scaled = go * fp8_scale_dL_dY
         bits_fp8 = to_fp8_saturated(go_scaled, torch.float8_e5m2)
         empty_grads = None, None, None, None, None, None
-        res = Float8Tensor(bits_fp8, fp8_scale_dL_dY, go.dtype, emulate=ctx.emulate)
+        res = Float8Tensor(bits_fp8, fp8_scale_dL_dY, go.dtype, mm_config=ctx.mm_config)
         return res, *empty_grads
 
 
@@ -131,6 +131,11 @@ class Float8LinearMixin(object):
         # will access the scale when it has ensured that it is on GPU.
         self._float8_tensor_ctor = lambda *args, **kwargs: Float8Tensor(*args, **kwargs)
 
+        # Defines the behavior of the matmul in the forward and backward
+        # Forward we use fast_accum, backwards we do not
+        self.forward_config = ScaledMMConfig(self.emulate, True if not self.emulate else False)
+        self.backward_config = ScaledMMConfig(self.emulate, False)
+
     def cast_x_to_float8(
         self, x: torch.Tensor, is_amax_initialized: bool
     ) -> torch.Tensor:
@@ -154,7 +159,7 @@ class Float8LinearMixin(object):
             is_amax_initialized,
         )
         x_fp8 = Float8Tensor.to_float8(
-            x, self.fp8_scale_x, torch.float8_e4m3fn, self.fp8_amax_x, self.emulate
+            x, self.fp8_scale_x, torch.float8_e4m3fn, self.fp8_amax_x, self.forward_config
         )
         return x_fp8
 
@@ -172,7 +177,7 @@ class Float8LinearMixin(object):
             is_amax_initialized,
         )
         w_fp8 = Float8Tensor.to_float8(
-            w, self.fp8_scale_w, torch.float8_e4m3fn, self.fp8_amax_w, self.emulate
+            w, self.fp8_scale_w, torch.float8_e4m3fn, self.fp8_amax_w, self.forward_config
         )
         return w_fp8
 
@@ -187,7 +192,7 @@ class Float8LinearMixin(object):
             self.fp8_scale_dL_dY,
             scale_fn_name,
             self.is_amax_initialized,
-            emulate,
+            self.backward_config,
         )
         return y
 
@@ -259,7 +264,8 @@ class Float8Linear(Float8LinearMixin, torch.nn.Linear):
         new_mod = cls(mod.in_features, mod.out_features, bias=False)
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
-        new_mod.emulate = emulate
+        new_mod.forward_config = ScaledMMConfig(emulate, True if not emulate else False)
+        new_mod.backward_config = ScaledMMConfig(emulate, False)
         if mod.bias is not None:
             new_mod.bias_dtype = mod.bias.dtype
         # I think its okay to send all params and buffers to device

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import torch
 from float8_experimental.float8_python_api import addmm_float8_unwrapped
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
 from float8_experimental.float8_utils import is_row_major
 from torch.utils._pytree import tree_map
 
@@ -33,7 +33,9 @@ def implements(aten_ops):
 )
 def float8_desugar_op(aten_op, args, kwargs=None):
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
-    return Float8Tensor(new_data, args[0]._scale, args[0]._orig_dtype, args[0]._emulate)
+    return Float8Tensor(
+        new_data, args[0]._scale, args[0]._orig_dtype, args[0]._mm_config
+    )
 
 
 @implements([aten.sum.dim_IntList])
@@ -76,13 +78,22 @@ def float8_mm(aten_op, args, kwargs=None):
     b = args[1]
     a_data, a_scale, b_data, b_scale = preprocess_addmm(a, b)
     output_dtype = a._orig_dtype
-    if a._emulate:
-        assert a._emulate == b._emulate
+    a_mm_config: ScaledMMConfig = a._mm_config
+    b_mm_config: ScaledMMConfig = b._mm_config
+    mm_config: ScaledMMConfig = a_mm_config.merge(b_mm_config)
+    if mm_config.emulate:
         return torch.ops.aten.mm_float8_emulated(
             a._data, a._scale, b._data, b._scale, output_dtype
         )[0]
     tensor_out, amax = addmm_float8_unwrapped(
-        a_data, a_scale, b_data, b_scale, output_dtype, output_scale=None, bias=None
+        a_data,
+        a_scale,
+        b_data,
+        b_scale,
+        output_dtype,
+        output_scale=None,
+        bias=None,
+        use_fast_accum=mm_config.use_fast_accum,
     )
     return tensor_out
 
@@ -100,14 +111,23 @@ def float8_addmm(aten_op, args, kwargs=None):
     a_data, a_scale, b_data, b_scale = preprocess_addmm(a, b)
     output_dtype = a._orig_dtype
     assert bias.dtype == output_dtype, "bias dtype must match output dtype"
-    if a._emulate:
-        assert a._emulate == b._emulate
+    a_mm_config: ScaledMMConfig = a._mm_config
+    b_mm_config: ScaledMMConfig = b._mm_config
+    mm_config: ScaledMMConfig = a_mm_config.merge(b_mm_config)
+    if mm_config.emulate:
         out = torch.ops.aten.mm_float8_emulated(
             a._data, a._scale, b._data, b._scale, output_dtype
         )[0]
         return out + bias
     tensor_out, amax = addmm_float8_unwrapped(
-        a_data, a_scale, b_data, b_scale, output_dtype, output_scale=None, bias=bias
+        a_data,
+        a_scale,
+        b_data,
+        b_scale,
+        output_dtype,
+        output_scale=None,
+        bias=bias,
+        use_fast_accum=mm_config.use_fast_accum,
     )
     return tensor_out
 
@@ -132,5 +152,5 @@ def autocast_to_copy(aten_op, args, kwargs=None):
         torch.bfloat16,
     }, "Only support floating point conversion for autocast w/ Float8Tensor"
     return Float8Tensor(
-        args[0]._data, args[0]._scale, kwargs["dtype"], args[0]._emulate
+        args[0]._data, args[0]._scale, kwargs["dtype"], args[0]._mm_config
     )

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -16,7 +16,7 @@ from float8_experimental.float8_linear_utils import (
     LinearType,
     sync_float8_amax_and_scale_history,
 )
-from float8_experimental.float8_python_api import mm_float8
+from float8_experimental.float8_python_api import addmm_float8_unwrapped
 from float8_experimental.float8_tensor import Float8Tensor
 from float8_experimental.float8_utils import (
     amax_to_scale,
@@ -186,7 +186,8 @@ class TestScaledMM:
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
-    def test_scaled_mm_vs_emulated(self, base_dtype):
+    @pytest.mark.parametrize("use_fast_accum", [True, False])
+    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
         input_dtype = torch.float8_e4m3fn
         output_dtype = base_dtype
@@ -201,11 +202,16 @@ class TestScaledMM:
         a_fp8 = Float8Tensor.to_float8(a, a_scale, input_dtype)
         b_fp8 = Float8Tensor.to_float8(b, b_scale, input_dtype)
 
-        out_scaled_mm, output_amax_scaled = mm_float8(
-            a_fp8, b_fp8, output_dtype=output_dtype, emulate=False
+        out_scaled_mm, output_amax_scaled = addmm_float8_unwrapped(
+            a_fp8._data,
+            a_fp8._scale,
+            b_fp8._data,
+            b_fp8._scale,
+            output_dtype=output_dtype,
+            use_fast_accum=use_fast_accum,
         )
-        out_emulated, output_amax_emulated = mm_float8(
-            a_fp8, b_fp8, output_dtype=output_dtype, emulate=True
+        out_emulated, output_amax_emulated = torch.ops.aten.mm_float8_emulated(
+            a_fp8._data, a_fp8._scale, b_fp8._data, b_fp8._scale, output_dtype
         )
 
         if output_dtype != base_dtype:


### PR DESCRIPTION
Note this breaks compile with 
``` Shell
  File "/home/drisspg/meta/pytorch/torch/_dynamo/exc.py", line 193, in unimplemented
    raise Unsupported(msg)
torch._dynamo.exc.Unsupported: call_function args: TensorVariable() TensorVariable() ConstantVariable(dtype) UserDefinedObjectVariable(ScaledMMConfig)


from user code:
   File "/home/drisspg/meta/scripts/fp8/dynamic_linear.py", line 42, in model
    return m_fp8(layer_norm(a))
  File "/home/drisspg/meta/pytorch/torch/nn/modules/module.py", line 1519, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/drisspg/meta/float8_experimental/float8_experimental/dynamic_linear/dynamic_float8_linear.py", line 47, in forward
    x_fp8 = self.cast_to_float8(x)
  File "/home/drisspg/meta/float8_experimental/float8_experimental/dynamic_linear/dynamic_float8_linear.py", line 67, in cast_to_float8
    return Float8Tensor.to_float8(

```
In the past this has been a red hearing for other graph breaks but this might be real? 

I think torch.autograd.function doens't like this?
cc @zou3519 

