### PR TITLE
Small changes to enable fp8 on xlformers to test multi-gpu

### DIFF
--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -120,7 +120,9 @@ def swap_linear_with_float8_linear(
             swap_linear_with_float8_linear(child, module, emulate)
 
 
-def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_classes = None) -> None:
+def sync_float8_amax_and_scale_history(
+    model: torch.nn.Module, fp8_classes=None
+) -> None:
     """
     Manages the float8 amax and scale bookkeeping. In detail, it does the
     following:
@@ -144,6 +146,7 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_classes = Non
     if fp8_classes is None:
         from float8_experimental.float8_linear import Float8Linear
         from float8_experimental.float8_linear_nots import Float8LinearNoTensorSubclass
+
         fp8_classes = [Float8Linear, Float8LinearNoTensorSubclass]
 
     for name, child in model.named_modules():

--- a/float8_experimental/tp_linear.py
+++ b/float8_experimental/tp_linear.py
@@ -109,6 +109,7 @@ class Float8ColumnParallelLinear(Float8LinearMixin, ColumnParallelLinear):
     def extra_repr(self) -> str:
         return f"in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
 
+
 class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
     """
     Same as `RowParallelLinear`, but with single GPU compute in float8.
@@ -204,6 +205,7 @@ class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
 
     def extra_repr(self) -> str:
         return f"in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}, input_is_parallel={self.input_is_parallel}"
+
 
 def swap_tp_linear_with_float8_linear(model, emulate=False):
     """


### PR DESCRIPTION
- If the model is casted to bf16 (model = model.to(get_torch_dtype(dtype))), dtype = bf16 is also passed to the scale_a parameter of the float8 tensor, and caused 
```
output, output_amax = torch._scaled_mm(
RuntimeError: scale_a must be float scalar
```
- The float8Linear classes used in multi-gpu are Float8Column/RowParallelLinear, sync_float8_amax_and_scale_history needs to identify these class types.