### PR TITLE
Allow for modifying the scaled_mm compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,17 @@ for _ in range(N_ITER):
     optimizer.step()
 ```
 
-# code tips
+# 🧭 Code Organization
 
-* `float8_experimental/float8_linear.py` - `Float8Linear` (main user facing entry point for delayed scaling)
-* `float8_experimental/float8_dynamic_linear.py` - `Float8DynamicLinear` (main user facing entry point for dynamic scaling)
-* `float8_experimental/float8_tensor.py` - `Float8Tensor`, which allows `Float8Linear` to abide by the `x.dtype == x.grad.dtype` restriction
+* `float8_experimental/float8_linear.py`
+    - `Float8Linear` (main user facing entry point for delayed scaling)
+* `float8_experimental/float8_dynamic_linear.py`
+    - `Float8DynamicLinear` (main user facing entry point for dynamic scaling)
+* `float8_experimental/float8_tensor.py`
+    - `Float8Tensor`, which allows `Float8Linear` to abide by the `x.dtype == x.grad.dtype` restriction
+    - `ScaledMMConfig` defines the semantics for matmul in the forward and backwards pass
 
-# testing
+# Testing
 
 ```bash
 # run single-GPU unit tests
@@ -117,7 +121,7 @@ pytest test/test_compile.py
 ./test/run_everything.sh
 ```
 
-# benchmarking
+# Benchmarking
 
 ```bash
 # benchmark the torch._scaled_mm function on LLaMa 2 70B shapes
@@ -130,4 +134,3 @@ pytest test/test_compile.py
 
 # License
 PyTorch has a BSD 3-Clause License, as found in the LICENSE file.
-

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -10,9 +10,9 @@ import torch
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
+    ScaledMMConfig,
     tensor_already_casted_to_fp8,
     to_fp8_no_autograd,
-    ScaledMMConfig
 )
 from float8_experimental.float8_utils import tensor_to_scale
 
@@ -40,7 +40,7 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
             return gradY, None
         gradY_scale = tensor_to_scale(gradY, torch.float8_e5m2)
         fp8_tensor = to_fp8_no_autograd(
-            gradY, gradY_scale, torch.float8_e5m2, ctx.emulate, mm_config=ctx.mm_config
+            gradY, gradY_scale, torch.float8_e5m2, mm_config=ctx.mm_config
         )
         return fp8_tensor, None
 
@@ -78,7 +78,7 @@ class Float8DynamicLinear(torch.nn.Linear):
         )
 
     def cast_to_float8_e5m2_bw(self, gradY: torch.Tensor) -> torch.Tensor:
-        return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate, self.backward_config)
+        return NoopFwToFloat8E5M2Bw.apply(gradY, self.backward_config)
 
     @classmethod
     def from_float(cls, mod, emulate: bool = False) -> "Float8DynamicLinear":

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -12,6 +12,7 @@ from float8_experimental.float8_tensor import (
     Float8Tensor,
     tensor_already_casted_to_fp8,
     to_fp8_no_autograd,
+    ScaledMMConfig
 )
 from float8_experimental.float8_utils import tensor_to_scale
 
@@ -27,9 +28,9 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
     def forward(
         ctx,
         tensor,
-        emulate: bool,
+        mm_config: ScaledMMConfig,
     ):
-        ctx.emulate = emulate
+        ctx.mm_config = mm_config
         return tensor
 
     @staticmethod
@@ -39,7 +40,7 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
             return gradY, None
         gradY_scale = tensor_to_scale(gradY, torch.float8_e5m2)
         fp8_tensor = to_fp8_no_autograd(
-            gradY, gradY_scale, torch.float8_e5m2, ctx.emulate
+            gradY, gradY_scale, torch.float8_e5m2, ctx.emulate, mm_config=ctx.mm_config
         )
         return fp8_tensor, None
 
@@ -73,11 +74,11 @@ class Float8DynamicLinear(torch.nn.Linear):
             return inpt_tensor
         scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn)
         return Float8Tensor.to_float8(
-            inpt_tensor, scale, torch.float8_e4m3fn, emulate=self.emulate
+            inpt_tensor, scale, torch.float8_e4m3fn, mm_config=self.forward_config
         )
 
     def cast_to_float8_e5m2_bw(self, gradY: torch.Tensor) -> torch.Tensor:
-        return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate)
+        return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate, self.backward_config)
 
     @classmethod
     def from_float(cls, mod, emulate: bool = False) -> "Float8DynamicLinear":
@@ -97,5 +98,6 @@ class Float8DynamicLinear(torch.nn.Linear):
             new_mod = cls(**super_kwargs)
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
-        new_mod.emulate = emulate
+        new_mod.forward_config = ScaledMMConfig(emulate, True if not emulate else False)
+        new_mod.backward_config = ScaledMMConfig(emulate, False)
         return new_mod

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -161,7 +161,6 @@ class Float8LinearMixin(object):
         self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor([1.0]))
 
         # Whether to emulate the fp8 matmul logic in float32
-        # self.emulate = False
         self.forward_config = ScaledMMConfig()
         self.backward_config = ScaledMMConfig()
 
@@ -255,9 +254,7 @@ class Float8LinearMixin(object):
         )
         return w_fp8
 
-    def cast_y_to_float8_in_bw(
-        self, y: torch.Tensor, emulate: bool = False
-    ) -> torch.Tensor:
+    def cast_y_to_float8_in_bw(self, y: torch.Tensor) -> torch.Tensor:
         scale_fn_name = self.recipe.scale_fn_name
         y = NoopFwToFloat8E5M2Bw.apply(
             y,
@@ -307,7 +304,7 @@ class Float8Linear(Float8LinearMixin, torch.nn.Linear):
         y = torch.matmul(x_fp8, w_fp8.t())
 
         # Cast gradY to float8_e5m2 during backward
-        y = self.cast_y_to_float8_in_bw(y, self.emulate)
+        y = self.cast_y_to_float8_in_bw(y)
 
         if self.bias is not None:
             y = y + self.bias.to(y.dtype)

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -160,7 +160,7 @@ class Float8LinearMixin(object):
         )
         self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor([1.0]))
 
-        # Whether to emulate the fp8 matmul logic in float32
+        # Defines the behavior of the matmul in the forward and backward pass
         self.forward_config = ScaledMMConfig()
         self.backward_config = ScaledMMConfig()
 

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -20,7 +20,11 @@ import float8_experimental.config as config
 
 import torch
 
-from float8_experimental.float8_tensor import Float8Tensor, to_fp8_no_autograd, ScaledMMConfig
+from float8_experimental.float8_tensor import (
+    Float8Tensor,
+    ScaledMMConfig,
+    to_fp8_no_autograd,
+)
 
 from float8_experimental.float8_utils import (
     amax_history_to_scale,
@@ -99,7 +103,9 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
 
         fp8_amax_dL_dY.fill_(tensor_to_amax(go))
 
-        res = to_fp8_no_autograd(go, fp8_scale_dL_dY, torch.float8_e5m2, ctx.emulate, mm_config=ctx.mm_config)
+        res = to_fp8_no_autograd(
+            go, fp8_scale_dL_dY, torch.float8_e5m2, mm_config=ctx.mm_config
+        )
         empty_grads = None, None, None, None, None, None
         return res, *empty_grads
 
@@ -155,7 +161,9 @@ class Float8LinearMixin(object):
         self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor([1.0]))
 
         # Whether to emulate the fp8 matmul logic in float32
-        self.emulate = False
+        # self.emulate = False
+        self.forward_config = ScaledMMConfig()
+        self.backward_config = ScaledMMConfig()
 
         # Note: is_amax_initialized is not a buffer to avoid data dependent
         # control flow visible to dynamo
@@ -194,11 +202,6 @@ class Float8LinearMixin(object):
             if self._buffers[key] is not None:
                 self._buffers[key] = self._buffers[key].to(torch.float32)
 
-        # Defines the behavior of the matmul in the forward and backward
-        # Forward we use fast_accum, backwards we do not
-        self.forward_config = ScaledMMConfig(self.emulate, True if not self.emulate else False)
-        self.backward_config = ScaledMMConfig(self.emulate, False)
-
     def cast_x_to_float8(
         self, x: torch.Tensor, is_amax_initialized: bool
     ) -> torch.Tensor:
@@ -221,7 +224,11 @@ class Float8LinearMixin(object):
             is_amax_initialized,
         )
         x_fp8 = Float8Tensor.to_float8(
-            x, self.fp8_scale_x, torch.float8_e4m3fn, self.fp8_amax_x, self.forward_config
+            x,
+            self.fp8_scale_x,
+            torch.float8_e4m3fn,
+            self.fp8_amax_x,
+            self.forward_config,
         )
         return x_fp8
 
@@ -240,7 +247,11 @@ class Float8LinearMixin(object):
         )
 
         w_fp8 = Float8Tensor.to_float8(
-            w, self.fp8_scale_w, torch.float8_e4m3fn, self.fp8_amax_w, self.forward_config
+            w,
+            self.fp8_scale_w,
+            torch.float8_e4m3fn,
+            self.fp8_amax_w,
+            self.forward_config,
         )
         return w_fp8
 
@@ -319,10 +330,12 @@ class Float8Linear(Float8LinearMixin, torch.nn.Linear):
         new_mod = cls(mod.in_features, mod.out_features, bias=False)
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
+
+        # Defines the behavior of the matmul in the forward and backward
+        # Forward we use fast_accum, backwards we do not
         new_mod.forward_config = ScaledMMConfig(emulate, True if not emulate else False)
         new_mod.backward_config = ScaledMMConfig(emulate, False)
-        # if mod.bias is not None:
-        #     new_mod.bias_dtype = mod.bias.dtype
+
         # I think its okay to send all params and buffers to device
         new_mod.to(mod.weight.device)
         return new_mod

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -122,10 +122,7 @@ def swap_linear_with_float8_linear(
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        print(f"Emulating: {emulate}")
-        new_mod = module_cls.from_float(module, emulate=emulate)
-        print(f"New mod: {new_mod.forward_config}")
-        return new_mod
+        return module_cls.from_float(module, emulate=emulate)
 
     # Mark all modules to skip as visited
     root_module = module

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -122,7 +122,10 @@ def swap_linear_with_float8_linear(
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        return module_cls.from_float(module, emulate=emulate)
+        print(f"Emulating: {emulate}")
+        new_mod = module_cls.from_float(module, emulate=emulate)
+        print(f"New mod: {new_mod.forward_config}")
+        return new_mod
 
     # Mark all modules to skip as visited
     root_module = module

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -15,7 +15,7 @@ from typing import Optional, Tuple
 import float8_experimental.float8_aten_api  # noqa
 
 import torch
-from float8_experimental.float8_tensor import Float8Tensor
+
 
 # [Note] Usage of scales
 # The meaning of scale in this library can be found in the definition of the Float8Tensor

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -17,15 +17,20 @@ import float8_experimental.float8_aten_api  # noqa
 import torch
 from float8_experimental.float8_tensor import Float8Tensor
 
-
+# [Note] Usage of scales
+# The meaning of scale in this library can be found in the definition of the Float8Tensor
+# Cublas defines scale to always mean a multiplicative factor for the respective matrices
+# For a,b going from fp8 -> fp32 we multiple by the inverse of the scale
+# For output going from fp32 -> fp8 we multiply by the scale
 def addmm_float8_unwrapped(
     a_data: torch.Tensor,
     a_scale: torch.Tensor,
     b_data: torch.Tensor,
     b_scale: torch.tensor,
     output_dtype: torch.dtype,
-    output_scale: Optional[torch.Tensor],
+    output_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
+    use_fast_accum: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     This is the unwrapped version of addmm_float8, which does not take in Float8Tensors
@@ -43,6 +48,7 @@ def addmm_float8_unwrapped(
             scale_a=a_inverse_scale,
             scale_b=b_inverse_scale,
             scale_result=output_scale,
+            use_fast_accum=use_fast_accum,
         )
         output += bias
         return output, output_amax
@@ -54,41 +60,6 @@ def addmm_float8_unwrapped(
         scale_a=a_inverse_scale,
         scale_b=b_inverse_scale,
         scale_result=output_scale,
+        use_fast_accum=use_fast_accum,
     )
     return output, output_amax
-
-
-# [Note] Usage of scales
-# The meaning of scale in this library can be found in the definition of the Float8Tensor
-# Cublas defines scale to always mean a multiplicative factor for the respective matrices
-# For a,b going from fp8 -> fp32 we multiple by the inverse of the scale
-# For output going from fp32 -> fp8 we multiply by the scale
-def mm_float8(
-    a: Float8Tensor,  # input 1
-    b: Float8Tensor,  # input 2
-    output_dtype: torch.dtype,  # output dtype
-    output_scale: Optional[torch.Tensor] = None,  # output scale, precomputed
-    emulate: bool = False,  # whether to emulate the operation using fp32
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Performs a matrix multiplication of two Float8Tensors `a` and `b`.
-
-    Args:
-        a: The first matrix multiplication term.
-        b: The second matrix multiplication term.
-        output_dtype: The output tensor's dtype.
-        output_scale: The output tensor's scale, precomputed.
-        emulate: Whether to emulate the operation using fp32.
-
-    Returns:
-        torch.Tensor: The result of the matrix multiplication.
-    """
-    if emulate:
-        assert output_scale is None, "unsupported"
-        return torch.ops.aten.mm_float8_emulated(
-            a._data, a._scale, b._data, b._scale, output_dtype
-        )
-
-    return addmm_float8_unwrapped(
-        a._data, a._scale, b._data, b._scale, output_dtype, output_scale
-    )

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 from typing import Dict, Optional
+from dataclasses import dataclass
 
 import torch
 
@@ -135,7 +136,7 @@ class ToFloat8ConstrFunc(torch.autograd.Function):
         if amax_buffer is not None:
             amax_buffer.fill_(tensor_to_amax(tensor))
 
-        return to_fp8_no_autograd(tensor, scale, float8_dtype, emulate)
+        return to_fp8_no_autograd(tensor, scale, float8_dtype, mm_config=mm_config)
 
     @staticmethod
     def backward(ctx, g):
@@ -182,15 +183,15 @@ class Float8Tensor(torch.Tensor):
     _data: torch.Tensor
     _scale: torch.Tensor
     _orig_dtype: torch.dtype
-    _emulate: bool
-    __slots__ = ["_data", "_scale", "_orig_dtype", "_emulate"]
+    _mm_config: ScaledMMConfig
+    __slots__ = ["_data", "_scale", "_orig_dtype", "_mm_config"]
 
     def __new__(
         cls,
         data: torch.Tensor,
         scale: torch.Tensor,
         orig_dtype: torch.dtype,
-        emulate=False,
+        mm_config: Optional[ScaledMMConfig] = None,
     ):
         assert (
             scale.numel() == 1
@@ -211,16 +212,17 @@ class Float8Tensor(torch.Tensor):
         self._data = data
         self._scale = scale
         self._orig_dtype = orig_dtype
-        self._emulate = emulate
+        self._mm_config = mm_config if mm_config is not None else ScaledMMConfig()
+
         return self
 
     def __repr__(self):
-        return f"Float8Tensor(dtype={self._data.dtype}, scale={self._scale}, emulate={self._emulate}\nas_orig_prec={self.to_original_precision()}"
+        return f"Float8Tensor(dtype={self._data.dtype}, scale={self._scale}, mm_config={self._mm_config}\nas_orig_prec={self.to_original_precision()}"
 
     def __tensor_flatten__(self):
         ctx = {
             "_orig_dtype": self._orig_dtype,
-            "_emulate": self._emulate,
+            "_mm_config": self._mm_config,
         }
         return ["_data", "_scale"], ctx
 
@@ -231,7 +233,7 @@ class Float8Tensor(torch.Tensor):
             inner_tensors["_data"],
             inner_tensors["_scale"],
             metadata["_orig_dtype"],
-            metadata["_emulate"],
+            metadata["_mm_config"],
         )
 
     def to_original_precision(self):
@@ -244,7 +246,8 @@ class Float8Tensor(torch.Tensor):
         scale: torch.Tensor,
         float8_dtype: torch.dtype,
         amax_buffer: Optional[torch.Tensor] = None,
-        emulate: bool = False,
+        # emulate: bool = False,
+        mm_config: Optional[ScaledMMConfig] = None
     ):
         """Converts a higher precision tensor to float8 in a differentiable way.
 
@@ -258,11 +261,7 @@ class Float8Tensor(torch.Tensor):
             Float8Tensor: a float8 tensor
         """
         return ToFloat8ConstrFunc.apply(
-            tensor,
-            scale,
-            float8_dtype,
-            amax_buffer,
-            emulate,
+            tensor, scale, float8_dtype, amax_buffer, mm_config
         )
 
     @classmethod

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -84,7 +84,7 @@ def to_fp8_no_autograd(
         x: the tensor to convert
         scale: the scale to use to convert the tensor
         float8_dtype: the float8 dtype to use
-        mm_config: configuration for the scaled_mm will bread from this dataclass
+        mm_config: Defines the configuration for the scaled_mm
     """
     x_scaled = x * x_scale
     bits_fp8 = to_fp8_saturated(x_scaled, float8_dtype)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -362,7 +362,8 @@ class TestFloat8LinearUtils(unittest.TestCase):
             module = nn.Linear(3, 3)
             module = swap_linear_with_float8_linear(module, module_cls, emulate=emulate)
             self.assertIsInstance(module, module_cls)
-            self.assertEqual(module.emulate, emulate)
+            self.assertEqual(module.forward_config.emulate, emulate)
+            self.assertEqual(module.backward_config.emulate, emulate)
 
     def test_swap_root_linear_with_children_raises(self):
         for module_cls, emulate in itertools.product(

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -21,7 +21,7 @@ from float8_experimental.float8_linear_utils import (
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
 )
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
 
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
@@ -118,7 +118,7 @@ class TestGraphBreaks(DynamoTestCase):
                 self.fp8_scale_x,
                 torch.float8_e4m3fn,
                 self.fp8_amax_x,
-                emulate=True,  # TODO: I set this to True so that people on A100 can test, but once fix is in, set to False
+                ScaledMMConfig(),
             )
             if self.graph_break:
                 torch._dynamo.graph_break()
@@ -181,9 +181,9 @@ class TestGraphBreaks(DynamoTestCase):
             type(y_compiled._orig_dtype)
         )
         assert isinstance(
-            y_compiled._emulate, bool
+            y_compiled._mm_config.emulate, bool
         ), "Float8Tensor._emulate should be a bool but got {}".format(
-            type(y_compiled._emulate)
+            type(y_compiled._mm_config.emulate)
         )
 
 

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -18,7 +18,7 @@ from float8_experimental.float8_dynamic_linear import (
     NoopFwToFloat8E5M2Bw,
 )
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
 from float8_experimental.float8_tensor_parallel import (
     Float8ColwiseParallel,
     Float8RowwiseParallel,
@@ -152,7 +152,7 @@ def test_dtensor_fp8_autograd(mesh: DeviceMesh, size=16):
     )
 
     out = torch.nn.functional.linear(dist_x_fp8, dist_weight_fp8)
-    out = NoopFwToFloat8E5M2Bw.apply(out, False)
+    out = NoopFwToFloat8E5M2Bw.apply(out, ScaledMMConfig())
     assert isinstance(out, DTensor), f"Expected DTensor, got {type(out)}"
     loss = torch.sum(torch.abs(out - dist_target))
     loss.backward()


### PR DESCRIPTION
# Summary

This does two things:
1.  Creates a new named_tuple type `ScaledMMConfig` that is used to control the behavior of the scaled_mm op. This includes, emulate, fast_accumulation, and fp8_out_dtype(the latter is not currently used).  It replaces the emulate arg and strings it through all the relevant infra, and updates test accordingly.
2. This adds the fp8 fast accum mode and enables it for the forward path and not the backward pass.


### Performance
With settings use_fast_accum in the forward using the linear_float8 benchmark:

![image](https://github.com/pytorch-labs/float8_experimental/assets/32754868/8510814e-88d0-402c-9676-d4afe8fef2a0)

|    | shape               |   Speedup_with_False |   Speedup_with_True |   Percentage_Gain |
|---:|:--------------------|---------------------:|--------------------:|------------------:|
|  0 | (16384, 1024, 8192) |             1.19086  |            1.26397  |           6.13912 |
|  1 | (16384, 3584, 8192) |             1.42227  |            1.48921  |           4.70629 |
|  2 | (16384, 8192, 1280) |             0.970685 |            0.986167 |           1.59497 |
|  3 | (16384, 8192, 7168) |             1.50755  |            1.54886  |           2.74022 |
