### PR TITLE
Changes to enable fp8 on multi devices

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -105,13 +105,21 @@ class Float8LinearMixin(object):
         history_len = self.recipe.history_len
 
         self.register_always_float32_buffer("fp8_amax_x", torch.tensor(E4M3_MAX_POS))
-        self.register_always_float32_buffer("fp8_amax_history_x", torch.zeros(history_len))
+        self.register_always_float32_buffer(
+            "fp8_amax_history_x", torch.zeros(history_len)
+        )
         self.register_always_float32_buffer("fp8_scale_x", torch.tensor(1.0))
         self.register_always_float32_buffer("fp8_amax_w", torch.tensor(E4M3_MAX_POS))
-        self.register_always_float32_buffer("fp8_amax_history_w", torch.zeros(history_len))
+        self.register_always_float32_buffer(
+            "fp8_amax_history_w", torch.zeros(history_len)
+        )
         self.register_always_float32_buffer("fp8_scale_w", torch.tensor(1.0))
-        self.register_always_float32_buffer("fp8_amax_dL_dY", torch.tensor(E5M2_MAX_POS))
-        self.register_always_float32_buffer("fp8_amax_history_dL_dY", torch.zeros(history_len))
+        self.register_always_float32_buffer(
+            "fp8_amax_dL_dY", torch.tensor(E5M2_MAX_POS)
+        )
+        self.register_always_float32_buffer(
+            "fp8_amax_history_dL_dY", torch.zeros(history_len)
+        )
         self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor(1.0))
         # Whether to emulate the fp8 matmul logic in float32
         self.emulate = False
@@ -140,7 +148,9 @@ class Float8LinearMixin(object):
         # will access the scale when it has ensured that it is on GPU.
         self._float8_tensor_ctor = lambda *args, **kwargs: Float8Tensor(*args, **kwargs)
 
-    def register_always_float32_buffer(self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True) -> None:
+    def register_always_float32_buffer(
+        self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True
+    ) -> None:
         self.register_buffer(name=name, tensor=tensor, persistent=persistent)
         self.always_float32_buffers.add(name)
 

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -143,10 +143,10 @@ def sync_float8_amax_and_scale_history(
     if fp8_classes is None:
         from float8_experimental.float8_linear import Float8Linear
 
-        fp8_classes = [Float8Linear]
+        fp8_classes = Float8Linear
 
     for name, child in model.named_modules():
-        if not any(isinstance(child, a) for a in fp8_classes):
+        if not isinstance(child, fp8_classes):
             continue
 
         #

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -142,6 +142,7 @@ def sync_float8_amax_and_scale_history(
 
     if fp8_classes is None:
         from float8_experimental.float8_linear import Float8Linear
+
         fp8_classes = [Float8Linear]
 
     for name, child in model.named_modules():

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -117,7 +117,9 @@ def swap_linear_with_float8_linear(
             swap_linear_with_float8_linear(child, module, emulate)
 
 
-def sync_float8_amax_and_scale_history(model: torch.nn.Module) -> None:
+def sync_float8_amax_and_scale_history(
+    model: torch.nn.Module, fp8_classes=None
+) -> None:
     """
     Manages the float8 amax and scale bookkeeping. In detail, it does the
     following:
@@ -138,10 +140,12 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module) -> None:
     # the reductions into one and probably make the history update faster.
     # Lazy import to avoid circular dependency
 
-    from float8_experimental.float8_linear import Float8Linear
+    if fp8_classes is None:
+        from float8_experimental.float8_linear import Float8Linear
+        fp8_classes = [Float8Linear]
 
     for name, child in model.named_modules():
-        if not isinstance(child, (Float8Linear)):
+        if not any(isinstance(child, a) for a in fp8_classes):
             continue
 
         #

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -196,6 +196,21 @@ class TestFloat8Linear:
 
         # Cast the module to dtype
         m = m.to(dtype=linear_dtype)
+        # Check amax buffer types
+        for key in [
+            "fp8_amax_x",
+            "fp8_amax_history_x",
+            "fp8_scale_x",
+            "fp8_amax_w",
+            "fp8_amax_history_w",
+            "fp8_scale_w",
+            "fp8_amax_dL_dY",
+            "fp8_amax_history_dL_dY",
+            "fp8_scale_dL_dY",
+        ]:
+            assert (
+                m._buffers[key].dtype == torch.float32
+            ), f"{key}.dtype is {m._buffers[key].dtype}, expected torch.float32"
 
         # autocast off
         x = torch.randn(16, 32, device="cuda", dtype=linear_dtype)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -182,7 +182,9 @@ class TestFloat8Linear:
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     def test_type_cast(self, linear_type: LinearType, linear_dtype: torch.dtype):
-        emulate = (not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0))
+        emulate = (
+            not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0)
+        )
         x_shape = (16, 16)
 
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)


### PR DESCRIPTION
- If the model is casted to bf16 (model = model.to(get_torch_dtype(dtype))), dtype = bf16 is also passed to the scale_a parameter of the float8 tensor, and caused
```
output, output_amax = torch._scaled_mm(
RuntimeError: scale_a must be float scalar
```
- The float8Linear classes used in multi-gpu are Float8Column/RowParallelLinear, sync_float8_amax_and_scale_history needs to identify these class types.