### PR TITLE
Small changes in linear float8 benchmark

### DIFF
--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -157,6 +157,19 @@ def main(
                     y = te_linear(input_tensor)
                 y.sum().backward()
 
+        def n_times(n, fn, *args, **kwargs):
+            def wrapper(*args, **kwargs):
+                for _ in range(n):
+                    fn(*args, **kwargs)
+            return wrapper
+
+        REPEAT_N = 100
+
+        if REPEAT_N > 1:
+            ref_forw_backward = n_times(REPEAT_N, ref_forw_backward)
+            float8_forw_backward = n_times(REPEAT_N, float8_forw_backward)
+            te_forw_backward = n_times(REPEAT_N, te_forw_backward)
+
         if compile:
             ref_forw_backward = torch.compile(ref_forw_backward)
             float8_forw_backward = torch.compile(float8_forw_backward)
@@ -169,6 +182,7 @@ def main(
             float8_forw_backward()
             if transformer_engine_installed:
                 te_forw_backward()
+
 
         ref_time = benchmark_torch_function_in_microseconds(ref_forw_backward) * 1e-6
         float8_time = (

--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -161,14 +161,14 @@ def main(
             def wrapper(*args, **kwargs):
                 for _ in range(n):
                     fn(*args, **kwargs)
+
             return wrapper
 
         REPEAT_N = 100
 
-        if REPEAT_N > 1:
-            ref_forw_backward = n_times(REPEAT_N, ref_forw_backward)
-            float8_forw_backward = n_times(REPEAT_N, float8_forw_backward)
-            te_forw_backward = n_times(REPEAT_N, te_forw_backward)
+        ref_forw_backward = n_times(REPEAT_N, ref_forw_backward)
+        float8_forw_backward = n_times(REPEAT_N, float8_forw_backward)
+        te_forw_backward = n_times(REPEAT_N, te_forw_backward)
 
         if compile:
             ref_forw_backward = torch.compile(ref_forw_backward)
@@ -182,7 +182,6 @@ def main(
             float8_forw_backward()
             if transformer_engine_installed:
                 te_forw_backward()
-
 
         ref_time = benchmark_torch_function_in_microseconds(ref_forw_backward) * 1e-6
         float8_time = (

--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -183,13 +183,21 @@ def main(
             if transformer_engine_installed:
                 te_forw_backward()
 
-        ref_time = benchmark_torch_function_in_microseconds(ref_forw_backward) * 1e-6
+        ref_time = (
+            benchmark_torch_function_in_microseconds(ref_forw_backward)
+            * 1e-6
+            / REPEAT_N
+        )
         float8_time = (
-            benchmark_torch_function_in_microseconds(float8_forw_backward) * 1e-6
+            benchmark_torch_function_in_microseconds(float8_forw_backward)
+            * 1e-6
+            / REPEAT_N
         )
         if transformer_engine_installed:
             te_time_sec = (
-                benchmark_torch_function_in_microseconds(te_forw_backward) * 1e-6
+                benchmark_torch_function_in_microseconds(te_forw_backward)
+                * 1e-6
+                / REPEAT_N
             )
         else:
             te_time_sec = None


### PR DESCRIPTION
Looking at the track of single float8 linear layer, there is a bubble on gpu at the beginning of a linear layer,
<img width="1206" alt="Screenshot 2023-11-30 at 5 01 06 PM" src="https://github.com/pytorch-labs/float8_experimental/assets/58683402/069c5a41-a94f-4e2d-a198-ae8b2cf4158a">

However, if we run the float8 linear layer in actual models with multiple layers, the bubble on gpu can be avoided, 
<img width="1122" alt="Screenshot 2023-11-30 at 5 02 38 PM" src="https://github.com/pytorch-labs/float8_experimental/assets/58683402/780c80fa-0245-484c-b76a-9a58e263c47a">


So, modified the benchmark to run the float8 linear layer multiple times to get the speed up that is more close to the actual use case.

The original results:
```
        name                shape       ref_dtype  compiled  ref_time_sec  pt_fp8_time_sec  te_fp8_time_sec  pt_fp8_speedup  te_fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16      True      0.002120         0.002264         0.002053        0.936327        1.032413
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16      True      0.001875         0.001739         0.001813        1.078139        1.034173
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16      True      0.010021         0.006798         0.006482        1.474114        1.545999
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16      True      0.005233         0.003797         0.003759        1.378418        1.392425
4  attn.wqkv  (16384, 8192, 1280)   torch.float16      True      0.002282         0.002319         0.002049        0.983933        1.113905
5    attn.w0  (16384, 1024, 8192)   torch.float16      True      0.001869         0.001691         0.001806        1.105511        1.034655
6    ffn.w13  (16384, 8192, 7168)   torch.float16      True      0.010197         0.006802         0.006607        1.499079        1.543460
7     ffn.w2  (16384, 3584, 8192)   torch.float16      True      0.005496         0.003722         0.003754        1.476622        1.464103
```

The results of running more times:
```
        name                shape       ref_dtype  compiled  ref_time_sec  pt_fp8_time_sec  te_fp8_time_sec  pt_fp8_speedup  te_fp8_speedup
0  attn.wqkv  (16384, 8192, 1280)  torch.bfloat16      True      0.203050         0.194429         0.170328        1.044343        1.192110
1    attn.w0  (16384, 1024, 8192)  torch.bfloat16      True      0.179131         0.133893         0.142089        1.337869        1.260700
2    ffn.w13  (16384, 8192, 7168)  torch.bfloat16      True      1.019652         0.674814         0.662380        1.511012        1.539375
3     ffn.w2  (16384, 3584, 8192)  torch.bfloat16      True      0.548669         0.349620         0.349280        1.569329        1.570858
4  attn.wqkv  (16384, 8192, 1280)   torch.float16      True      0.217842         0.198974         0.172005        1.094826        1.266485
5    attn.w0  (16384, 1024, 8192)   torch.float16      True      0.179531         0.129683         0.142738        1.384383        1.257768
6    ffn.w13  (16384, 8192, 7168)   torch.float16      True      1.076060         0.678630         0.672458        1.585637        1.600189
7     ffn.w2  (16384, 3584, 8192)   torch.float16      True      0.581987         0.350504         0.347816        1.660431        1.673260
```
