### PR TITLE
Fixes benchmark script if TE is not installed

### DIFF
--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -168,7 +168,8 @@ def main(
 
         ref_forw_backward = n_times(REPEAT_N, ref_forw_backward)
         float8_forw_backward = n_times(REPEAT_N, float8_forw_backward)
-        te_forw_backward = n_times(REPEAT_N, te_forw_backward)
+        if transformer_engine_installed:
+            te_forw_backward = n_times(REPEAT_N, te_forw_backward)
 
         if compile:
             ref_forw_backward = torch.compile(ref_forw_backward)


### PR DESCRIPTION
Summary:

As titled, I have a fresh checkout and hit this

Test Plan:

```
python ./benchmarks/bench_linear_float8.py -o ../tmp/test.txt --compile
```

Reviewers:

Subscribers:

Tasks:

Tags: