### PR TITLE
fixes up the profiling script to turn on full-graph torch.compile mod…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 float8_experimental/__pycache__/*
 finetune/__pycache__/*
 test/__pycache__/*
+torch_compile_debug/*
 tmp/*
 benchmarks/data/*
 


### PR DESCRIPTION
…e for fw+bw

This makes it easier to look at profiling stuff for fw+bw.

We should clean up the scale syncing later to make it more torch.compile fullgraph friendly.

Summary:

Test Plan:

```
TORCH_LOGS="+dynamo" python benchmarks/profile_linear_float8.py ../tmp/profile --compile=True --linear_type="delayed" 2>&1 | with-proxy gh gist create
// results:https://gist.github.com/vkuzo/e184bb5c436d7e2b682de051aa57c9f3
```

Reviewers:

Subscribers:

Tasks:

Tags: