### PR TITLE
Test fsdp compile

### DIFF
--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Test numerics of single GPU vs FSDP of toy model. At a high level:
+1. start with reference input and state dict for a single GPU model
+2. run fw+bw+optim on single GPU, save the results
+3. run fw+bw+optim with FSDP, save the results
+4. verify that the outputs and state dicts after optim update match
+
+later 1-4 can be repeated for fp16, various combinations of fp8, etc.
+"""
+
+import os
+import warnings
+from typing import Callable, List, Optional, Tuple
+
+import fire
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.utils.benchmark as benchmark
+from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear_utils import (
+    swap_linear_with_float8_linear,
+    sync_float8_amax_and_scale_history,
+    update_float8_amax_and_scale_history,
+)
+from torch.distributed.fsdp import (
+    FullStateDictConfig,
+    FullyShardedDataParallel as FSDP,
+    StateDictType,
+)
+
+# Check if transformer_engine is installed
+transformer_engine_installed = False
+try:
+    import transformer_engine.pytorch as te
+    from transformer_engine.common import recipe
+
+    transformer_engine_installed = True
+except ImportError:
+    print("transformer_engine not installed and we won't compare against this")
+
+
+torch.manual_seed(0)
+
+B, M, K, N = 32, 32, 32, 32
+lr = 0.01
+N_ITER = 11
+
+def benchmark_torch_function_in_microseconds(
+    func: Callable,
+    *args,
+    **kwargs,
+) -> float:
+    t0 = benchmark.Timer(
+        stmt="func(*args, **kwargs)",
+        globals={"args": args, "kwargs": kwargs, "func": func},
+    )
+    return t0.blocked_autorange().median * 1e6
+
+
+def setup(rank, world_size):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12355"
+
+    # initialize the process group
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+def get_model(K, N, is_fp8, is_te, base_dtype=torch.float32):
+    modules = [
+        nn.Linear(K, N, dtype=base_dtype)
+        if not is_te
+        else te.Linear(K, N, params_dtype=base_dtype),
+        nn.ReLU(),
+    ]
+    N_LAYERS = 10
+    # N linear layers
+    for _ in range(N_LAYERS - 1):
+        if is_te:
+            modules.append(te.Linear(N, N, params_dtype=base_dtype))
+        else:
+            modules.append(nn.Linear(N, N, dtype=base_dtype))
+        modules.append(nn.ReLU())
+    m = nn.Sequential(*modules)
+    if is_fp8:
+        assert not is_te, "`is_fp8` (using pytorch fp8) can't be used with `is_te`"
+        swap_linear_with_float8_linear(m, Float8Linear, emulate=False)
+    return m
+
+
+def fsdp_main(rank, world_size, args):
+    setup(rank, world_size)
+    torch.cuda.set_device(rank)
+
+    base_dtype, input_global, compile = args
+
+    # basic distributed data sampling
+    bsz_global = input_global.shape[0]
+    assert B % world_size == 0
+    bsz_local_start = int(rank / world_size * B)
+    bsz_local_end = int((rank + 1) / world_size * B)
+    input_tensor = input_global[bsz_local_start:bsz_local_end].to(rank)
+
+    fp8_model = FSDP(
+        # torch.compile(
+        get_model(K, N, is_fp8=True, is_te=False, base_dtype=base_dtype).to(rank),
+        # ),
+        use_orig_params=compile,
+    )
+    if rank == 0:
+        print(fp8_model)
+
+    # fp8_model = torch.compile(fp8_model)
+    fp8_optimizer = torch.optim.SGD(fp8_model.parameters(), lr=lr * world_size)
+
+    def float8_forw_backward():
+        # TODO: Has to use the optimizer in float forward_backward, otherwise there will be errors of fsdp compile, need to figure out.
+        fp8_optimizer.zero_grad()
+        y_local = fp8_model(input_tensor)
+        y_local.sum().backward()
+        sync_float8_amax_and_scale_history(fp8_model)
+        fp8_optimizer.step()
+        return y_local
+
+    ref_model = FSDP(
+        get_model(K, N, is_fp8=False, is_te=False, base_dtype=base_dtype).to(rank),
+        use_orig_params=compile,
+    )
+    ref_optimizer = torch.optim.SGD(ref_model.parameters(), lr=lr * world_size)
+
+    def ref_forw_backward():
+        ref_optimizer.zero_grad()
+        ref_model(input_tensor).sum().backward()
+        ref_optimizer.step()
+
+    if transformer_engine_installed:
+        te_model = FSDP(
+            get_model(K, N, is_fp8=False, is_te=True, base_dtype=base_dtype).to(rank),
+            use_orig_params=compile,
+        )
+        fp8_format = recipe.Format.HYBRID
+        fp8_recipe = recipe.DelayedScaling(
+            fp8_format=fp8_format, amax_history_len=16, amax_compute_algo="max"
+        )
+        if rank == 0:
+            print(te_model)
+
+        te_optimizer = torch.optim.SGD(ref_model.parameters(), lr=lr * world_size)
+
+        def te_forw_backward():
+            te_optimizer.zero_grad()
+            with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+                y = te_model(input_tensor)
+            y.sum().backward()
+            te_optimizer.step()
+
+    if compile:
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
+
+        ref_forw_backward = torch.compile(ref_forw_backward)
+
+        float8_forw_backward = torch.compile(
+            float8_forw_backward, options={"trace.graph_diagram": True}
+        )
+
+        explain_output = torch._dynamo.explain(float8_forw_backward)()
+        print(explain_output)
+
+        # Compiling TE_linear fails but they are already compiling under the hood
+        # if transformer_engine_installed:
+        #     te_forw_backward = torch.compile(te_forw_backward)
+
+    def run_n_iterations(n, fn):
+        for _ in range(n):
+            fn()
+        # make sure training is done on all ranks
+        dist.barrier()
+
+    run_n_iterations(5, ref_forw_backward)
+    run_n_iterations(5, float8_forw_backward)
+    if transformer_engine_installed:
+        run_n_iterations(5, te_forw_backward)
+
+    N_ITER = 10
+    ref_time = (
+        benchmark_torch_function_in_microseconds(
+            run_n_iterations, N_ITER, ref_forw_backward
+        )
+        * 1e-6
+        / N_ITER
+    )
+    float8_time = (
+        benchmark_torch_function_in_microseconds(
+            run_n_iterations, N_ITER, float8_forw_backward
+        )
+        * 1e-6
+        / N_ITER
+    )
+    if transformer_engine_installed:
+        te_time_sec = (
+            benchmark_torch_function_in_microseconds(
+                run_n_iterations, N_ITER, te_forw_backward
+            )
+            * 1e-6
+            / N_ITER
+        )
+    else:
+        te_time_sec = None
+
+    if rank == 0:
+        print("ref_time", ref_time)
+        print("float8_time", float8_time)
+        print("te_time_sec", te_time_sec)
+        print("float8 speedup", ref_time / float8_time)
+        if transformer_engine_installed:
+            print("te speedup", ref_time / te_time_sec)
+
+    cleanup()
+
+
+def run():
+    compile = True
+    base_dtype = torch.bfloat16
+    print(f"{base_dtype = }")
+    print(f"{compile = }")
+    # generate input data
+    ref_input = torch.randn(B, M, K).cuda().to(base_dtype)
+    # run fsdp model
+    WORLD_SIZE = torch.cuda.device_count()
+    print(f"{WORLD_SIZE = }")
+    args = (base_dtype, ref_input, compile)
+    mp.spawn(fsdp_main, args=(WORLD_SIZE, args), nprocs=WORLD_SIZE, join=True)
+
+
+if __name__ == "__main__":
+    fire.Fire(run)

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -157,7 +157,7 @@ def fsdp_main(rank, world_size, args):
             y.sum().backward()
             te_optimizer.step()
 
-    float8_forw_backward()
+    # float8_forw_backward()
 
     if compile:
         torch._inductor.config.reorder_for_compute_comm_overlap = True

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -125,6 +125,9 @@ def fsdp_main(rank, world_size, args):
 
     def float8_forw_backward():
         fp8_optimizer.zero_grad()
+        y_local = fp8_model(input_tensor)
+        y_local.sum().backward()
+        fp8_optimizer.step()
         if compile:
             compiled_sync_float8_amax_and_scale_history(
                 fp8_model, fp8_layers=fp8_layers, combine_reduction=True
@@ -133,10 +136,6 @@ def fsdp_main(rank, world_size, args):
             sync_float8_amax_and_scale_history(
                 fp8_model, fp8_layers=fp8_layers, combine_reduction=True
             )
-        y_local = fp8_model(input_tensor)
-        y_local.sum().backward()
-        fp8_optimizer.step()
-        return y_local
 
     ref_model = get_model(K, N, is_fp8=False, is_te=False, base_dtype=base_dtype).to(
         rank

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -3,15 +3,6 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-"""
-Test numerics of single GPU vs FSDP of toy model. At a high level:
-1. start with reference input and state dict for a single GPU model
-2. run fw+bw+optim on single GPU, save the results
-3. run fw+bw+optim with FSDP, save the results
-4. verify that the outputs and state dicts after optim update match
-
-later 1-4 can be repeated for fp16, various combinations of fp8, etc.
-"""
 
 import os
 import warnings

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -121,7 +121,7 @@ def fsdp_main(rank, world_size, args):
         fp8_optimizer.zero_grad()
         y_local = fp8_model(input_tensor)
         y_local.sum().backward()
-        sync_float8_amax_and_scale_history(fp8_model, fp8_layers, combine_reduction=True)
+        sync_float8_amax_and_scale_history(fp8_model, fp8_layers=fp8_layers, combine_reduction=True)
         fp8_optimizer.step()
         return y_local
 

--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -154,9 +154,9 @@ def main(profile_path: Path, compile: bool, linear_type: str):
             out.sum().backward()
 
     if transformer_engine_installed:
-        # Create an FP8 recipe. Note: All input args are optional.
+        fp8_format = recipe.Format.HYBRID
         fp8_recipe = recipe.DelayedScaling(
-            margin=0, interval=1, fp8_format=recipe.Format.E4M3
+            fp8_format=fp8_format, amax_history_len=16, amax_compute_algo="max"
         )
         te_linear = te.Linear(params.K, params.N, bias=params.input_bias).to(
             device="cuda", dtype=params.ref_dtype

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -117,112 +117,9 @@ def swap_linear_with_float8_linear(
             swap_linear_with_float8_linear(child, module, emulate)
 
 
-def sync_float8_amax_and_scale_history(
-    model: torch.nn.Module, fp8_classes=None
-) -> None:
-    """
-    Manages the float8 amax and scale bookkeeping. In detail, it does the
-    following:
-    1. in distributed contexts, syncs amax values across workers
-    2. adds the `amax` values to history
-    3. calculates the scales to be used for next iteration
-    4. sets the `amax_and_scale_synced` flag on the Float8Linear modules
-       to signal that they have been synced
-
-    TODO(future): design the UX for this (context manager, etc)
-
-    Args:
-        model (torch.nn.Module): The model to track amaxes for
-    """
-
-    # For now, this is written in a naive way to maximize code readability.
-    # TODO(future): benchmark and optimize as needed, we can combine all
-    # the reductions into one and probably make the history update faster.
-    # Lazy import to avoid circular dependency
-
+def get_float8_layers(model: torch.nn.Module, fp8_classes=None):
     if fp8_classes is None:
-        from float8_experimental.float8_linear import Float8Linear
-
-        fp8_classes = Float8Linear
-
-    for name, child in model.named_modules():
-        if not isinstance(child, fp8_classes):
-            continue
-
-        #
-        # 1. in distributed contexts, syncs amax values across workers
-        #
-        if dist.is_initialized():
-            dist.all_reduce(child.fp8_amax_x, op=dist.ReduceOp.MAX)
-            dist.all_reduce(child.fp8_amax_w, op=dist.ReduceOp.MAX)
-            dist.all_reduce(child.fp8_amax_dL_dY, op=dist.ReduceOp.MAX)
-
-        #
-        # 2. adds the `amax` values to history
-        #
-        _update_history_with_new_amax(child.fp8_amax_x, child.fp8_amax_history_x)
-        _update_history_with_new_amax(child.fp8_amax_w, child.fp8_amax_history_w)
-        _update_history_with_new_amax(
-            child.fp8_amax_dL_dY, child.fp8_amax_history_dL_dY
-        )
-
-        #
-        # 3. calculate the scales
-        #
-        # TODO what to do with x_dtype
-        x_dtype = child.last_seen_input_dtype
-        new_scale = amax_history_to_scale(
-            child.fp8_amax_history_x,
-            torch.float8_e4m3fn,
-            x_dtype,
-            child.recipe.scale_fn_name,
-        )
-        child.fp8_scale_x.copy_(new_scale)
-        new_scale = amax_history_to_scale(
-            child.fp8_amax_history_w,
-            torch.float8_e4m3fn,
-            x_dtype,
-            child.recipe.scale_fn_name,
-        )
-        child.fp8_scale_w.copy_(new_scale)
-        new_scale = amax_history_to_scale(
-            child.fp8_amax_history_dL_dY,
-            torch.float8_e5m2,
-            x_dtype,
-            child.recipe.scale_fn_name,
-        )
-        child.fp8_scale_dL_dY.copy_(new_scale)
-
-        #
-        # 4. set a flag to signal amaxes/scales are ready
-        #
-        child.amax_and_scale_synced = True
-
-
-def sync_float8_amax_and_scale_history_test_conbine_reduction(
-    model: torch.nn.Module, fp8_classes=None
-) -> None:
-    """
-    Manages the float8 amax and scale bookkeeping. In detail, it does the
-    following:
-    1. in distributed contexts, syncs amax values across workers
-    2. adds the `amax` values to history
-    3. calculates the scales to be used for next iteration
-    4. sets the `amax_and_scale_synced` flag on the Float8Linear modules
-       to signal that they have been synced
-
-    TODO(future): design the UX for this (context manager, etc)
-
-    Args:
-        model (torch.nn.Module): The model to track amaxes for
-    """
-
-    # For now, this is written in a naive way to maximize code readability.
-    # TODO(future): benchmark and optimize as needed, we can combine all
-    # the reductions into one and probably make the history update faster.
-    # Lazy import to avoid circular dependency
-
-    if fp8_classes is None:
+        # Lazy import to avoid circular dependency
         from float8_experimental.float8_linear import Float8Linear
 
         fp8_classes = Float8Linear
@@ -232,42 +129,70 @@ def sync_float8_amax_and_scale_history_test_conbine_reduction(
         child for name, child in model.named_modules() if isinstance(child, fp8_classes)
     ]
 
-    if dist.is_initialized():
-        fp8_amax_x_tensor = torch.tensor(
-            [child.fp8_amax_x for child in fp8_layers],
-            dtype=torch.float32,
-            device="cuda",
-            requires_grad=False,
-        )
-        fp8_amax_w_tensor = torch.tensor(
-            [child.fp8_amax_w for child in fp8_layers],
-            dtype=torch.float32,
-            device="cuda",
-            requires_grad=False,
-        )
-        fp8_amax_dL_dY_tensor = torch.tensor(
-            [child.fp8_amax_dL_dY for child in fp8_layers],
-            dtype=torch.float32,
-            device="cuda",
-            requires_grad=False,
-        )
-        # print("fp8_amax_x_tensor, ", fp8_amax_x_tensor)
+    return fp8_layers
 
-        dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
-        dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
-        dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
+def sync_float8_amax_and_scale_history(
+    model: torch.nn.Module, fp8_layers, combine_reduction = False
+) -> None:
+    """
+    Manages the float8 amax and scale bookkeeping. In detail, it does the
+    following:
+    1. in distributed contexts, syncs amax values across workers
+    2. adds the `amax` values to history
+    3. calculates the scales to be used for next iteration
+    4. sets the `amax_and_scale_synced` flag on the Float8Linear modules
+       to signal that they have been synced
+
+    TODO(future): design the UX for this (context manager, etc)
+
+    Args:
+        model (torch.nn.Module): The model to track amaxes for
+    """
+
+    # For now, this is written in a naive way to maximize code readability.
+    # TODO(future): benchmark and optimize as needed, we can combine all
+    # the reductions into one and probably make the history update faster.
+
+    if dist.is_initialized():
+        if combine_reduction:
+            fp8_amax_x_tensor = torch.tensor(
+                [child.fp8_amax_x for child in fp8_layers],
+                dtype=torch.float32,
+                device="cuda",
+                requires_grad=False,
+            )
+            fp8_amax_w_tensor = torch.tensor(
+                [child.fp8_amax_w for child in fp8_layers],
+                dtype=torch.float32,
+                device="cuda",
+                requires_grad=False,
+            )
+            fp8_amax_dL_dY_tensor = torch.tensor(
+                [child.fp8_amax_dL_dY for child in fp8_layers],
+                dtype=torch.float32,
+                device="cuda",
+                requires_grad=False,
+            )
+            # print("fp8_amax_x_tensor, ", fp8_amax_x_tensor)
+            dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
+            dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
+            dist.all_reduce(fp8_amax_x_tensor, op=dist.ReduceOp.MAX)
 
     for idx in range(len(fp8_layers)):
         child = fp8_layers[idx]
-
         #
         # 1. in distributed contexts, syncs amax values across workers
         #
         if dist.is_initialized():
-            child.fp8_amax_x = fp8_amax_x_tensor[idx].clone()
-            child.fp8_amax_w = fp8_amax_w_tensor[idx].clone()
-            child.fp8_amax_dL_dY = fp8_amax_dL_dY_tensor[idx].clone()
-        # TODO: There are errors if no "clone()", need to figure out.
+            if combine_reduction:
+                # TODO: There are errors if no "clone()", need to figure out.
+                child.fp8_amax_x = fp8_amax_x_tensor[idx].clone()
+                child.fp8_amax_w = fp8_amax_w_tensor[idx].clone()
+                child.fp8_amax_dL_dY = fp8_amax_dL_dY_tensor[idx].clone()
+            else:
+                dist.all_reduce(child.fp8_amax_x, op=dist.ReduceOp.MAX)
+                dist.all_reduce(child.fp8_amax_w, op=dist.ReduceOp.MAX)
+                dist.all_reduce(child.fp8_amax_dL_dY, op=dist.ReduceOp.MAX)
 
         #
         # 2. adds the `amax` values to history

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -131,6 +131,7 @@ def get_float8_layers(model: torch.nn.Module, fp8_classes=None):
 
     return fp8_layers
 
+
 def sync_float8_amax_and_scale_history(
     model: torch.nn.Module, fp8_classes=None, fp8_layers=None, combine_reduction=False
 ) -> None:
@@ -157,6 +158,7 @@ def sync_float8_amax_and_scale_history(
         fp8_layers = get_float8_layers(model, fp8_classes)
 
     if dist.is_initialized():
+        # TODO: Testing if combine_reduction improves performance.
         if combine_reduction:
             fp8_amax_x_tensor = torch.tensor(
                 [child.fp8_amax_x for child in fp8_layers],

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -132,7 +132,7 @@ def get_float8_layers(model: torch.nn.Module, fp8_classes=None):
     return fp8_layers
 
 def sync_float8_amax_and_scale_history(
-    model: torch.nn.Module, fp8_layers, combine_reduction = False
+    model: torch.nn.Module, fp8_classes=None, fp8_layers=None, combine_reduction=False
 ) -> None:
     """
     Manages the float8 amax and scale bookkeeping. In detail, it does the
@@ -152,6 +152,9 @@ def sync_float8_amax_and_scale_history(
     # For now, this is written in a naive way to maximize code readability.
     # TODO(future): benchmark and optimize as needed, we can combine all
     # the reductions into one and probably make the history update faster.
+
+    if fp8_layers is None:
+        fp8_layers = get_float8_layers(model, fp8_classes)
 
     if dist.is_initialized():
         if combine_reduction:

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -59,7 +59,6 @@ def tensor_to_amax(x, distributed_reduction=False):
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will
     # happen elsewhere.
-    # TODO: The two lines need to be commente to workaround a fsdp compile error, need to figure this out
     if distributed_reduction and dist.is_initialized():
         dist.all_reduce(amax, op=dist.ReduceOp.MAX)
 

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -59,6 +59,7 @@ def tensor_to_amax(x, distributed_reduction=False):
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will
     # happen elsewhere.
+    # TODO: The two lines need to be commente to workaround a fsdp compile error, need to figure this out
     if distributed_reduction and dist.is_initialized():
         dist.all_reduce(amax, op=dist.ReduceOp.MAX)
 

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -108,6 +108,8 @@ def fsdp_main(rank, world_size, args):
         optimizer.step()
         return y_local
 
+    # TODO: Fix here. Running for one iteration and then compile is a workaround for compiling fsdp float8.
+    # A better way for compile is to FSDP(torch.compile(model)).
     forward_backward()
     if COMPILE:
         forward_backward = torch.compile(forward_backward)

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -47,7 +47,6 @@ output_fsdp_fname = os.path.join(data_dir, "output_fsdp.pt")
 B, M, K, N = 8, 8, 32, 32
 lr = 0.01
 N_ITER = 3
-N_ITER = 1
 
 
 def setup(rank, world_size):

--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -29,7 +29,7 @@ launch() {
     echo "✅ All Tests Passed ✅"
 }
 
-for IS_FP8 in False True
+for IS_FP8 in True # False True
 do
     launch
 done

--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -29,7 +29,7 @@ launch() {
     echo "✅ All Tests Passed ✅"
 }
 
-for IS_FP8 in True # False True
+for IS_FP8 in False True
 do
     launch
 done


### PR DESCRIPTION
- Added an initial benchmark for fsdp + fp8, benchmarks/bench_multi_gpu.py
  - Note that the benchmark has issues with "compile", please see the experiments doc for more context.
  - CUDA_VISIBLE_DEVICES=0,1 python benchmarks/bench_multi_gpu.py 2>&1 | tee logs

- Modified the existing test/test_fsdp.py to include compile.
  - The script can success with compile, but it's with a workaround. Please see the comment there for context.
  - Added relu layers after linear layers so that the numerics can be stable after several iterations and can be used to check accuracy results.

- In bench/profile_linear_float8.py, changed the TE FP8 receipt to be the same as PyTorch FP8.

- In sync_float8_amax_and_scale_history, added an option to combine all_reduce calls into one call.
  - Need to verify if this can bring performance gain.
  - Another option is to let each layer handle its own amax update and sync, which is the approach used by TE fp8.