### PR TITLE
Compile test fsdp

### DIFF
--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -146,9 +146,10 @@ def main(
             linear_float8(input_tensor).sum().backward()
 
         if transformer_engine_installed:
-            # Create an FP8 recipe. Note: All input args are optional.
+            # Use the same recipe as float8_linear.DelayedScalingRecipe
+            fp8_format = recipe.Format.HYBRID
             fp8_recipe = recipe.DelayedScaling(
-                margin=0, interval=1, fp8_format=recipe.Format.E4M3
+                fp8_format=fp8_format, amax_history_len=16, amax_compute_algo="max"
             )
             te_linear = te.Linear(K, N, bias=input_bias).to(device=device, dtype=dtype)
 

--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -166,9 +166,10 @@ def main(profile_path: Path, compile: bool, linear_type: str):
             out.sum().backward()
 
     if transformer_engine_installed:
-        # Create an FP8 recipe. Note: All input args are optional.
+        # Use the same recipe as float8_linear.DelayedScalingRecipe
+        fp8_format = recipe.Format.HYBRID
         fp8_recipe = recipe.DelayedScaling(
-            margin=0, interval=1, fp8_format=recipe.Format.E4M3
+            fp8_format=fp8_format, amax_history_len=16, amax_compute_algo="max"
         )
         te_linear = te.Linear(params.K, params.N, bias=params.input_bias).to(
             device="cuda", dtype=params.ref_dtype

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -111,7 +111,9 @@ def fsdp_main(rank, world_size, args):
 
     sync_float8_func = sync_float8_amax_and_scale_history
     if compile:
-        sync_float8_func = torch.compile(sync_float8_amax_and_scale_history, fullgraph=fullgraph)
+        sync_float8_func = torch.compile(
+            sync_float8_amax_and_scale_history, fullgraph=fullgraph
+        )
         # model = FSDP(torch.compile(model.module), use_orig_params=True)
         model = torch.compile(model, fullgraph=fullgraph)
 

--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -4,14 +4,14 @@
 set -e
 
 launch() {
-    echo "launching IS_FP8 $IS_FP8"
+    echo "launching IS_FP8 $IS_FP8, compile_fsdp $COMPILE, fullgraph $FULLGRAPH"
 
     # generate the test data
-    python test/test_fsdp.py --mode generate --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode generate --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     # generate single GPU model output and updated state dict
-    python test/test_fsdp.py --mode single_gpu --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode single_gpu --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     # generate FSDP model output and updated state dict
@@ -20,16 +20,19 @@ launch() {
     # the NCCL_NET setting is to work around transient issues on a
     #   specific host (`devgpu001.nha2`)
     NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 NCCL_NET=SOCKET python test/test_fsdp.py \
-        --mode fsdp --is_fp8 $IS_FP8
+        --mode fsdp --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
 
     # compare the outputs and state dicts and verify equivalence
-    python test/test_fsdp.py --mode analyze --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode analyze --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     echo "✅ All Tests Passed ✅"
 }
 
-for IS_FP8 in False True
+# IS_FP8, COMPILE, FULLGRAPH
+for i in False,False,False True,False,False True,True,False
 do
+    IFS=","; set -- $i;
+    IS_FP8=$1; COMPILE=$2; FULLGRAPH=$3
     launch
 done


### PR DESCRIPTION
Added an option in test_fsdp.py to compile fsdp.

When running "./test/test_fsdp.sh", three settings will be testest:
Fp8 = False
Fp8 = True, Compile = False
Fp8 = True, Compile = True (with fullgraph = False)

With compile mode, the numerics check can still pass.

However, note that the compile now works with a workaround. We still need to fix the issue.