### PR TITLE
Compile test fsdp

### DIFF
--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -4,14 +4,14 @@
 set -e
 
 launch() {
-    echo "launching IS_FP8 $IS_FP8"
+    echo "launching IS_FP8 $IS_FP8, compile_fsdp $COMPILE, fullgraph $FULLGRAPH"
 
     # generate the test data
-    python test/test_fsdp.py --mode generate --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode generate --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     # generate single GPU model output and updated state dict
-    python test/test_fsdp.py --mode single_gpu --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode single_gpu --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     # generate FSDP model output and updated state dict
@@ -20,16 +20,19 @@ launch() {
     # the NCCL_NET setting is to work around transient issues on a
     #   specific host (`devgpu001.nha2`)
     NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 NCCL_NET=SOCKET python test/test_fsdp.py \
-        --mode fsdp --is_fp8 $IS_FP8
+        --mode fsdp --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
 
     # compare the outputs and state dicts and verify equivalence
-    python test/test_fsdp.py --mode analyze --is_fp8 $IS_FP8
+    python test/test_fsdp.py --mode analyze --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
     echo "Success: ✅"
 
     echo "✅ All Tests Passed ✅"
 }
 
-for IS_FP8 in False True
+# IS_FP8, COMPILE, FULLGRAPH
+for i in False,False,False True,False,False True,True,False
 do
+    IFS=","; set -- $i;
+    IS_FP8=$1; COMPILE=$2; FULLGRAPH=$3
     launch
 done


### PR DESCRIPTION
Added an option in test_fsdp.py to compile fsdp. With compile mode, the numerics check can still pass.
However, note that the compile now works with a workaround. And fullgraph needs to be False. We still need to fix the issue.


When running "./test/test_fsdp.sh", three settings will be testet:
1. Fp8 = False
2. Fp8 = True, Compile = False
3. Fp8 = True, Compile = True (with fullgraph = False)

For example:
```
$ ./test/test_fsdp.sh
launching IS_FP8 False, compile_fsdp False, fullgraph False
-------------------------------------------Mode: generate-------------------------------------------
Success: ✅
------------------------------------------Mode: single_gpu------------------------------------------
Success: ✅
---------------------------------------------Mode: fsdp---------------------------------------------
NCCL version 2.19.3+cuda12.1
-------------------------------------------Mode: analyze--------------------------------------------
output testing single_gpu vs FSDP success
state dict testing single_gpu vs FSDP success
Success: ✅
✅ All Tests Passed ✅
launching IS_FP8 True, compile_fsdp False, fullgraph False
-------------------------------------------Mode: generate-------------------------------------------
Success: ✅
------------------------------------------Mode: single_gpu------------------------------------------
Success: ✅
---------------------------------------------Mode: fsdp---------------------------------------------
NCCL version 2.19.3+cuda12.1
-------------------------------------------Mode: analyze--------------------------------------------
output testing single_gpu vs FSDP success
state dict testing single_gpu vs FSDP success
Success: ✅
✅ All Tests Passed ✅
launching IS_FP8 True, compile_fsdp True, fullgraph False
-------------------------------------------Mode: generate-------------------------------------------
Success: ✅
------------------------------------------Mode: single_gpu------------------------------------------
Success: ✅
---------------------------------------------Mode: fsdp---------------------------------------------
NCCL version 2.19.3+cuda12.1
[rank0]:[2023-12-15 14:49:02,616] [0/0] torch._dynamo.variables.torch: [WARNING] Profiler function <class 'torch.autograd.profiler.record_function'> will be ignored
[rank0]:[2023-12-15 14:49:02,618] [0/0] torch._dynamo.variables.torch: [WARNING] Profiler function <class 'torch.autograd.profiler.record_function'> will be ignored
[rank1]:[2023-12-15 14:49:02,706] [0/0] torch._dynamo.variables.torch: [WARNING] Profiler function <class 'torch.autograd.profiler.record_function'> will be ignored
[rank1]:[2023-12-15 14:49:02,708] [0/0] torch._dynamo.variables.torch: [WARNING] Profiler function <class 'torch.autograd.profiler.record_function'> will be ignored
-------------------------------------------Mode: analyze--------------------------------------------
output testing single_gpu vs FSDP success
state dict testing single_gpu vs FSDP success
Success: ✅
✅ All Tests Passed ✅
```
