### PR TITLE
Fix an issue in sync_amax

### DIFF
--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -160,9 +160,9 @@ def sync_float8_amax_and_scale_history(
         # 1. in distributed contexts, syncs amax values across workers
         #
         if dist.is_initialized():
-            child.fp8_amax_x = fp8_amax_x_tensor[idx]
-            child.fp8_amax_w = fp8_amax_w_tensor[idx]
-            child.fp8_amax_dL_dY = fp8_amax_dL_dY_tensor[idx]
+            child.fp8_amax_x = fp8_amax_x_tensor[idx].clone()
+            child.fp8_amax_w = fp8_amax_w_tensor[idx].clone()
+            child.fp8_amax_dL_dY = fp8_amax_dL_dY_tensor[idx].clone()
 
         #
         # 2. adds the `amax` values to history


### PR DESCRIPTION
To fix this error
```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor []] is at version 1; expected version 0 instead.
```
----
Also tried 
```
@torch.no_grad()
 def sync_float8_amax_and_scale_history(
```
which didn't work.

----
We can look into if there are any better ways to fix this.

----
Test Plan:
./test/test_fsdp.sh 