### PR TITLE
[wip] makes dynamic linear support weight caching

### DIFF
--- a/float8_experimental/dynamic_linear/dynamic_float8_linear.py
+++ b/float8_experimental/dynamic_linear/dynamic_float8_linear.py
@@ -9,8 +9,9 @@ A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 
 import torch
 
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, calculate_amax_and_cast_to_float8
 from float8_experimental.float8_utils import tensor_to_scale, to_fp8_saturated
+import float8_experimental.config as config
 
 
 class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
@@ -47,14 +48,24 @@ class Float8DynamicLinear(torch.nn.Linear):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        if config.allocate_float8_weight_cache_buffers:
+            # this is a buffer to get `to(dtype)` for free
+            # TODO(future): hide this from serialization
+            # TODO(future): force this to stay in float8_e4m3fn
+            self.register_buffer(
+                "cached_fp8_weight",
+                torch.empty(self.weight.shape, dtype=torch.float8_e4m3fn),
+            )
+
         self.add_weight_tag()
 
     def forward(self, x):
-        x_fp8 = self.cast_to_float8(x)
+        x_fp8 = self.cast_x_to_float8(x)
         if getattr(self, "_w_fp8", None) is not None:  # FSDP handled the cast
             w_fp8 = self._w_fp8
         else:
-            w_fp8 = self.cast_to_float8(self.weight)
+            w_fp8 = self.cast_w_to_float8(self.weight)
 
         y = torch.nn.functional.linear(x_fp8, w_fp8, self.bias)
 
@@ -68,11 +79,43 @@ class Float8DynamicLinear(torch.nn.Linear):
         # To FSDP that this param is a weight
         self.weight._is_fp8_weight = True
 
-    def cast_to_float8(self, inpt_tensor):
+    def cast_x_to_float8(self, inpt_tensor):
         scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn)
         return Float8Tensor.to_float8(
             inpt_tensor, scale, torch.float8_e4m3fn, emulate=self.emulate
         )
+
+    def cast_w_to_float8(self, w):
+        with torch.no_grad():
+            scale = tensor_to_scale(w, torch.float8_e4m3fn)
+            if config.weight_cache_enabled:
+                assert config.allocate_float8_weight_cache_buffers, (
+                    "float8 weight cache buffer must be allocated using "
+                    + "`allocate_float8_weight_cache_buffers` to use the weight cache"
+                )
+                w_bits_fp8 = self.cached_fp8_weight
+            else:
+                # manual calculation of fp8 bits:
+                # 1. calculate the bits without Float8Tensor, without grad
+                # 2. store the bits here
+                # 3. create Float8Tensor from the bits calculated in 2
+                # motivation: this will take care of saving the bits without
+                # interacting with tensor subclasses, as w_fp8._data is not
+                # currently traceable by dynamo
+                w_bits_fp8 = calculate_amax_and_cast_to_float8(
+                    w, scale, torch.float8_e4m3fn, amax_buffer=None 
+                )
+                if config.allocate_float8_weight_cache_buffers:
+                    self.cached_fp8_weight.copy_(w_bits_fp8)
+        w_fp8 = Float8Tensor.to_float8(
+            w,
+            scale,
+            torch.float8_e4m3fn,
+            emulate=self.emulate,
+            cached_casted_weight=w_bits_fp8,
+        )
+        return w_fp8
+
 
     def cast_to_float8e5m2_bw(self, gradY):
         return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate)
@@ -92,4 +135,9 @@ class Float8DynamicLinear(torch.nn.Linear):
         new_mod.bias = mod.bias
         new_mod.emulate = emulate
         new_mod.add_weight_tag()
+        if config.allocate_float8_weight_cache_buffers:
+            new_mod.cached_fp8_weight = torch.empty(
+                new_mod.cached_fp8_weight.shape, 
+                dtype=new_mod.cached_fp8_weight.dtype,
+                device=new_mod.weight.device)
         return new_mod

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -234,15 +234,16 @@ class TestFloat8Linear:
             y.dtype == torch.bfloat16
         ), f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
 
+    @pytest.mark.parametrize("linear_type", [LinearType.DELAYED, LinearType.DYNAMIC])
     @pytest.mark.parametrize("use_compile", [False, True])
-    def test_weight_caching(self, use_compile):
+    def test_weight_caching(self, linear_type, use_compile):
         M, K, N = 16, 32, 64
         dtype = torch.bfloat16
         config.allocate_float8_weight_cache_buffers = True
 
         x = torch.randn(M, K, device="cuda", dtype=dtype)
         m_ref = nn.Linear(K, N, bias=True, device="cuda", dtype=dtype)
-        m = Float8Linear.from_float(copy.deepcopy(m_ref), emulate=False)
+        m = get_float8_linear(linear_type, m_ref, emulate=False).cuda()
 
         if use_compile:
             m = torch.compile(m)


### PR DESCRIPTION
Summary:

Works on single GPU, but not yet with FSDP

FSDP error (from LLaMa trainer), looks like weight_gradient is off by a factor of world_size:
https://gist.github.com/vkuzo/a6fd86085ea1fb05618dbd10fb7f00d1

Test Plan:

```
pytest test/test_base.py -s --sw -k weight_caching

// TODO before land: add test with autocast and FSDP
```

Reviewers:

Subscribers:

Tasks:

Tags: