### PR TITLE
add dynamic linear to __init__

### DIFF
--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -6,5 +6,6 @@
 # Lets define a few top level things here
 from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_tensor import Float8Tensor
+import float8_experimental.dynamic_linear
 
 __all__ = ["Float8Tensor", "Float8Linear"]


### PR DESCRIPTION
This is needed otherwise there will be import errors like:

```
    from float8_experimental.dynamic_linear.dynamic_float8_linear import Float8DynamicLinear
ModuleNotFoundError: No module named 'float8_experimental.dynamic_linear'
```