### PR TITLE
remove weight caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,28 +64,6 @@ model.foo.bar.fc2.sequence_parallel = True
 # the rest of the flow is the same as the single GPU flow
 ```
 
-## weight caching (very experimental)
-
-```python
-import float8_experimental.config as config
-
-m = Model(...)
-# before converting to `Float8Linear`, turn on weight cache buffer allocation
-config.allocate_float8_weight_cache_buffers = True
-
-# in the training loop, manually control the global weight caching setting
-for idx in N_ITER:
-    ...
-    if idx % n_microbatch == 0:
-        # if we are in the first pass of a new microbatch, repopulate the cache
-        config.weight_cache_enabled = False
-    elif idx % n_microbatch == 1:
-        # if we are in the second pass of a new microbatch, use cached weight
-        # this persists until `idx % n_microbatch == 0` again
-        config.weight_cache_enabled = True
-    ...
-```
-
 # high level technical design
 
 ## UX

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -4,23 +4,6 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-#
-# Weight caching.
-#
-
-# If True, allocates buffers for float8 weight cache
-allocate_float8_weight_cache_buffers = False
-
-# A global flag for controlling the weight cache, off by default. Intended
-# usage is for users to modify this from their training loop directly
-# according to their microbatching/pipeline parallel setup.
-# Note: this is currently a global flag for simplicity and dynamo performance.
-weight_cache_enabled = False
-
-#
-# Other
-#
-
 # If True, on the first iteration of Float8Linear the amaxes will be
 # initialized with the incoming data. As of 2023-12-30, this doesn't work
 # with autocast + torch.compile + FSDP. Enabling this option is nice for

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -20,10 +20,7 @@ import float8_experimental.config as config
 
 import torch
 
-from float8_experimental.float8_tensor import (
-    calculate_amax_and_cast_to_float8,
-    Float8Tensor,
-)
+from float8_experimental.float8_tensor import Float8Tensor
 
 from float8_experimental.float8_utils import (
     amax_history_to_scale,
@@ -182,15 +179,6 @@ class Float8LinearMixin(object):
         # and torch.compile, this option can disable them
         self.enable_pre_and_post_forward = config.enable_pre_and_post_forward
 
-        if config.allocate_float8_weight_cache_buffers:
-            # this is a buffer to get `to(dtype)` for free
-            # TODO(future): hide this from serialization
-            # TODO(future): force this to stay in float8_e4m3fn
-            self.register_buffer(
-                "cached_fp8_weight",
-                torch.empty(self.weight.shape, dtype=torch.float8_e4m3fn),
-            )
-
     def register_always_float32_buffer(
         self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True
     ) -> None:
@@ -247,32 +235,12 @@ class Float8LinearMixin(object):
             is_amax_initialized,
         )
 
-        if config.weight_cache_enabled:
-            assert config.allocate_float8_weight_cache_buffers, (
-                "float8 weight cache buffer must be allocated using "
-                + "`allocate_float8_weight_cache_buffers` to use the weight cache"
-            )
-            w_bits_fp8 = self.cached_fp8_weight
-        else:
-            # manual calculation of fp8 bits:
-            # 1. calculate the bits without Float8Tensor, without grad
-            # 2. store the bits here
-            # 3. create Float8Tensor from the bits calculated in 2
-            # motivation: this will take care of saving the bits without
-            # interacting with tensor subclasses, as w_fp8._data is not
-            # currently traceable by dynamo
-            w_bits_fp8 = calculate_amax_and_cast_to_float8(
-                self.weight, self.fp8_scale_w, torch.float8_e4m3fn, self.fp8_amax_w
-            )
-            if config.allocate_float8_weight_cache_buffers:
-                self.cached_fp8_weight.copy_(w_bits_fp8)
         w_fp8 = Float8Tensor.to_float8(
             w,
             self.fp8_scale_w,
             torch.float8_e4m3fn,
             self.fp8_amax_w,
             self.emulate,
-            cached_casted_weight=w_bits_fp8,
         )
         return w_fp8
 

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -156,8 +156,6 @@ def sync_float8_amax_and_scale_history(
 
     for idx in range(len(fp8_layers)):
         child = fp8_layers[idx]
-        # TODO(future): enable skipping weight related syncing if weight cache
-        # is on
 
         #
         # 1. in distributed contexts, syncs amax values across workers


### PR DESCRIPTION
Summary:

Removes most of
https://github.com/pytorch-labs/float8_experimental/pull/164

This isn't useful in the short term since it doesn't compose with FSDP + compile, and memory overhead is high.  We can bring it back later if needed.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: