### PR TITLE
remove unused FSDP float8 all-gather integration

### DIFF
--- a/float8_experimental/tp_linear.py
+++ b/float8_experimental/tp_linear.py
@@ -49,10 +49,7 @@ class Float8ColumnParallelLinear(Float8LinearMixin, ColumnParallelLinear):
                 input_parallel, self.is_amax_initialized
             )
 
-        if getattr(self, "_w_fp8", None) is not None:  # FSDP handled the cast
-            w_fp8 = self._w_fp8
-        else:
-            w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
+        w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
 
         # Matrix multiply.
         output_parallel = torch.matmul(input_parallel_fp8, w_fp8.t())
@@ -101,7 +98,6 @@ class Float8ColumnParallelLinear(Float8LinearMixin, ColumnParallelLinear):
         device_to_use = next(mod.parameters()).device
         new_mod.to(device_to_use)
         new_mod.emulate = emulate
-        new_mod.add_weight_tag()
         # TODO: test when creation is on cuda
         return new_mod
 
@@ -137,10 +133,7 @@ class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
             input_parallel, self.is_amax_initialized
         )
 
-        if getattr(self, "_w_fp8", None) is not None:  # FSDP handled the cast
-            w_fp8 = self._w_fp8
-        else:
-            w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
+        w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
 
         # Matrix multiply.
         output_parallel = torch.matmul(input_parallel_fp8, w_fp8.t())
@@ -196,7 +189,6 @@ class Float8RowParallelLinear(Float8LinearMixin, RowParallelLinear):
         device_to_use = next(mod.parameters()).device
         new_mod.to(device_to_use)
         new_mod.emulate = emulate
-        new_mod.add_weight_tag()
         return new_mod
 
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -175,11 +175,6 @@ class TestFloat8Linear:
             y.dtype == torch.bfloat16
         ), f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
 
-    def test_linear_float8_weight_tag(self) -> None:
-        m_ref = nn.Linear(16, 32, bias=False, device="cuda")
-        m_fp8 = Float8Linear.from_float(copy.deepcopy(m_ref))
-        assert m_fp8.weight._is_fp8_weight
-
     @pytest.mark.parametrize("linear_type", [LinearType.DELAYED, LinearType.DYNAMIC])
     @pytest.mark.parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]


### PR DESCRIPTION
Summary:

All of the removed code is outdated, we will try again with per-parameter sharding FSDP.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: