### PR TITLE
Add for option to use tensor hooks for Dynamic Linear

### DIFF
--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -14,3 +14,8 @@ enable_amax_init = True
 # this doesn't work with autocast + torch.compile + FSDP. Enabling this
 # option is useful for safety, but not strictly necessary.
 enable_pre_and_post_forward = True
+
+# If True, dynamic linear uses hooks for activation casting
+# TODO(before land): add test coverage for both cases
+# dynamic_use_activation_hooks = True
+# dynamic_use_activation_hooks = False

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -7,9 +7,10 @@
 A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 """
 
+import float8_experimental.config as config
 import torch
 
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, to_fp8_no_autograd
 from float8_experimental.float8_utils import tensor_to_scale, to_fp8_saturated
 
 
@@ -31,13 +32,23 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, gradY):
-        gradY_scale = tensor_to_scale(gradY, torch.float8_e5m2)
-        gradY_scaled = gradY * gradY_scale
-        bits_fp8 = to_fp8_saturated(gradY_scaled, torch.float8_e5m2)
-        return (
-            Float8Tensor(bits_fp8, gradY_scale, gradY.dtype, emulate=ctx.emulate),
-            None,
-        )
+        fp8_tensor = to_fp8_no_autograd(gradY, torch.float8_e5m2, ctx.emulate)
+        return fp8_tensor, None
+
+
+def cast_x_to_float8_e4m3fn_pre_hook(module, args):
+    """
+    Hook to cast the incoming activation to `torch.float8_e4m3fn`
+    """
+    return module.cast_to_float8_e4m3fn(args[0])
+
+
+def cast_dldy_to_float8_e5m2_backward_pre_hook(module, grad_output):
+    """
+    Hook to cast the incoming gradient to `torch.float8_e5m2`
+    """
+    gradY = grad_output[0]
+    return (to_fp8_no_autograd(gradY, torch.float8_e5m2, module.emulate),)
 
 
 class Float8DynamicLinear(torch.nn.Linear):
@@ -46,38 +57,65 @@ class Float8DynamicLinear(torch.nn.Linear):
     conversion to fp8 of the input and weight tensors.
     """
 
+    def __init__(self, use_activation_hooks: bool, **super_kwargs):
+        """
+        Args:
+            use_activation_hooks (bool): whether to use activation hooks for casting to and from float8
+        """
+        super().__init__(**super_kwargs)
+
+        self.use_activation_hooks = use_activation_hooks
+
     def forward(self, x):
-        x_fp8 = self.cast_to_float8(x)
-        w_fp8 = self.cast_to_float8(self.weight)
+        # cast x to float8_e4m3fn if not using activation hooks
+        x_fp8 = x if self.use_activation_hooks else self.cast_to_float8_e4m3fn(x)
+
+        # cast w to float8_e4m3fn
+        w_fp8 = self.cast_to_float8_e4m3fn(self.weight)
 
         y = torch.nn.functional.linear(x_fp8, w_fp8, self.bias)
 
-        # Cast gradY to float8_e5m2 during backward
-        y = self.cast_to_float8e5m2_bw(y)
+        # Cast gradY to float8_e5m2 during backward if not using activation hooks
+        if not self.use_activation_hooks:
+            y = self.cast_to_float8_e5m2_bw(y)
 
         return y
 
-    def cast_to_float8(self, inpt_tensor):
+    def cast_to_float8_e4m3fn(self, inpt_tensor: torch.Tensor) -> Float8Tensor:
         scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn)
         return Float8Tensor.to_float8(
             inpt_tensor, scale, torch.float8_e4m3fn, emulate=self.emulate
         )
 
-    def cast_to_float8e5m2_bw(self, gradY):
+    def cast_to_float8_e5m2_bw(self, gradY: torch.Tensor) -> torch.Tensor:
         return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate)
 
     @classmethod
-    def from_float(cls, mod, emulate: bool = False):
+    def from_float(
+        cls, mod, emulate: bool = False, use_activation_hooks: bool = False
+    ) -> "Float8DynamicLinear":
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
 
         Args:
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
+            use_activation_hooks (bool): whether to use activation hooks for casting to and from float8
         """
         with torch.device("meta"):
-            new_mod = cls(mod.in_features, mod.out_features, bias=False)
+            super_kwargs = {
+                "in_features": mod.in_features,
+                "out_features": mod.out_features,
+                "bias": False,
+            }
+            new_mod = cls(use_activation_hooks, **super_kwargs)
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
         new_mod.emulate = emulate
+        if new_mod.use_activation_hooks:
+            # install the hooks
+            new_mod.register_forward_pre_hook(cast_x_to_float8_e4m3fn_pre_hook)
+            new_mod.register_full_backward_pre_hook(
+                cast_dldy_to_float8_e5m2_backward_pre_hook
+            )
         return new_mod

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -298,14 +298,16 @@ class Float8Linear(Float8LinearMixin, torch.nn.Linear):
         return y
 
     @classmethod
-    def from_float(cls, mod, emulate: bool = False):
+    def from_float(cls, mod, emulate: bool = False, use_activation_hooks: bool = False):
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
 
         Args:
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
+            use_activation_hooks (bool): whether to use activation hooks instead of inlining the casting logic
         """
+        assert not use_activation_hooks, "use_activation_hooks is not supported yet!"
         # TODO Follow up! This is a great idea but we need the mixin base to create real
         # Tensors and the Linear base to create empty params
         # with torch.device("meta"):

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -23,13 +23,17 @@ REQUIRES_SYNC = {LinearType.DELAYED}
 
 
 def get_float8_linear(
-    linear_type: LinearType, linear_ref: torch.nn.Linear, emulate: bool = False
+    linear_type: LinearType,
+    linear_ref: torch.nn.Linear,
+    emulate: bool = False,
+    use_activation_hooks: bool = False,
 ):
     """Returns a Float8Linear module of the given type, initialized from linear_ref.
     Args:
         linear_type: The type of Float8Linear to return.
         linear_ref: The linear module to initialize from.
         emulate: Whether to emulate the fp8 matmul logic in float32.
+        use_activation_hooks: Whether to use activation hooks for dynamic linear.
     """
     LINEAR_TYPE_MAP = {
         LinearType.DELAYED: Float8Linear,
@@ -37,9 +41,12 @@ def get_float8_linear(
     }
     if linear_type not in LINEAR_TYPE_MAP:
         raise ValueError(f"linear_type must be one of {LINEAR_TYPE_MAP.keys()}")
-
+    if use_activation_hooks and linear_type != LinearType.DYNAMIC:
+        raise ValueError("use_activation_hooks is only supported for dynamic linear")
     return LINEAR_TYPE_MAP[linear_type].from_float(
-        copy.deepcopy(linear_ref), emulate=emulate
+        copy.deepcopy(linear_ref),
+        emulate=emulate,
+        use_activation_hooks=use_activation_hooks,
     )
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture
+def x_fail_activation_hooks(request):
+    use_activation_hooks = request.getfixturevalue("use_activation_hooks")
+    if use_activation_hooks:
+        request.node.add_marker(
+            pytest.mark.xfail(reason="use_activation_hooks is not supported for AOT")
+        )
+
+
+@pytest.fixture
+def x_fail_activation_hooks_with_delayed(request):
+    linear_type = request.getfixturevalue("linear_type")
+    use_activation_hooks = request.getfixturevalue("use_activation_hooks")
+    if use_activation_hooks and linear_type == linear_type.DELAYED:
+        request.node.add_marker(
+            pytest.mark.xfail(reason="use_activation_hooks is not supported for AOT")
+        )

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -120,6 +120,7 @@ class TestFloat8Linear:
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
     @pytest.mark.parametrize("linear_type", [LinearType.DELAYED, LinearType.DYNAMIC])
     @pytest.mark.parametrize("use_activation_hooks", [True, False])
+    @pytest.mark.usefixtures("x_fail_activation_hooks_with_delayed")
     def test_linear_nobias(
         self,
         x_shape,
@@ -136,8 +137,6 @@ class TestFloat8Linear:
                     f"CUDA capability {torch.cuda.get_device_capability()} < (9.0)"
                 )
                 pytest.skip()
-        if use_activation_hooks and linear_type != LinearType.DYNAMIC:
-            pytest.skip("use_activation_hooks is only supported for dynamic linear")
 
         x = torch.randn(*x_shape, device="cuda")
         m_ref = nn.Linear(16, 32, bias=False, device="cuda")
@@ -150,6 +149,7 @@ class TestFloat8Linear:
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_activation_hooks", [True, False])
+    @pytest.mark.usefixtures("x_fail_activation_hooks_with_delayed")
     def test_linear_bias(
         self,
         x_shape,
@@ -168,9 +168,6 @@ class TestFloat8Linear:
                 )
                 pytest.skip()
 
-        if use_activation_hooks and linear_type != LinearType.DYNAMIC:
-            pytest.skip("use_activation_hooks is only supported for dynamic linear")
-
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=True, device="cuda", dtype=linear_dtype)
         self._test_linear_impl(x, m_ref, linear_type, emulate, use_activation_hooks)
@@ -181,6 +178,7 @@ class TestFloat8Linear:
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_activation_hooks", [True, False])
+    @pytest.mark.usefixtures("x_fail_activation_hooks_with_delayed")
     def test_autocast_outputs(
         self,
         linear_type: LinearType,
@@ -197,9 +195,6 @@ class TestFloat8Linear:
                     f"CUDA capability {torch.cuda.get_device_capability()} < (9.0)"
                 )
                 pytest.skip()
-
-        if use_activation_hooks and linear_type != LinearType.DYNAMIC:
-            pytest.skip("use_activation_hooks is only supported for dynamic linear")
 
         m_ref = nn.Linear(32, 16, device="cuda", dtype=linear_dtype)
         m = get_float8_linear(linear_type, m_ref, emulate, use_activation_hooks)


### PR DESCRIPTION
# Summary

This is a duplicate of: https://github.com/pytorch-labs/float8_experimental/pull/170
With more testing, ideally I think we wouldn't have the choice between hooks and modified forwards and just use hooks. However compile does not appear to support this yet