### PR TITLE
Using hatchling produces better intellisense with vscode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
-# pyproject.toml
-
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "float8_experimental"


### PR DESCRIPTION
# Summary
The intellisense has been messed up in vscode for fp8_experimental and conda envs, I found that changing to hatchling fixes this issues.