### PR TITLE
Add tests for scaled_mm + DTensor

### DIFF
--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -12,8 +12,6 @@ import os
 
 import torch
 import torch.nn as nn
-from torch.distributed.device_mesh import init_device_mesh, DeviceMesh
-from torch.distributed._tensor import DTensor, distribute_tensor, Shard, Replicate
 
 # from fairscale.nn.model_parallel.layers import ColumnParallelLinear, RowParallelLinear
 
@@ -22,6 +20,8 @@ from float8_experimental.distributed_utils import _AllGatherFwSplitBw
 from float8_experimental.float8_python_api import mm_float8
 from float8_experimental.float8_tensor import Float8Tensor
 from float8_experimental.float8_utils import compute_error, tensor_to_scale
+from torch.distributed._tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 
 def setup_distributed():

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -58,9 +58,9 @@ def test_scaled_mm(mesh: DeviceMesh, size=16):
         assert isinstance(dist_y_fp8.to_local(), Float8Tensor)
         assert dist_x_fp8.to_local()._orig_dtype == torch.float32
         out_fp8 = torch.mm(dist_x_fp8, dist_y_fp8)
+        local_fp8_out = out_fp8.to_local()
         assert out_fp8.shape == expected_dt_out_shape[idx], (idx, local_fp8_out.shape)
 
-        local_fp8_out = out_fp8.to_local()
         # after mm the out dtype should be fp32
         assert local_fp8_out.dtype == torch.float32
 

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -7,20 +7,14 @@
 Test numerics of manually defined float16 TP vs float8 TP of toy models
 """
 
-import copy
 import os
 
 import torch
 import torch.nn as nn
 
-# from fairscale.nn.model_parallel.layers import ColumnParallelLinear, RowParallelLinear
-
-from float8_experimental.distributed_utils import _AllGatherFwSplitBw
-
-from float8_experimental.float8_python_api import mm_float8
 from float8_experimental.float8_tensor import Float8Tensor
-from float8_experimental.float8_utils import compute_error, tensor_to_scale
-from torch.distributed._tensor import distribute_tensor, DTensor, Replicate, Shard
+from float8_experimental.float8_utils import tensor_to_scale
+from torch.distributed._tensor import DTensor, Replicate, Shard
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Test numerics of manually defined float16 TP vs float8 TP of toy models
+"""
+
+import copy
+import os
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh, DeviceMesh
+from torch.distributed._tensor import DTensor, distribute_tensor, Shard, Replicate
+
+# from fairscale.nn.model_parallel.layers import ColumnParallelLinear, RowParallelLinear
+
+from float8_experimental.distributed_utils import _AllGatherFwSplitBw
+
+from float8_experimental.float8_python_api import mm_float8
+from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_utils import compute_error, tensor_to_scale
+
+
+def setup_distributed():
+    world_size = int(os.environ.get("WORLD_SIZE", -1))
+    device_mesh = init_device_mesh("cuda", (world_size,))
+    # seed must be the same in all processes
+    torch.manual_seed(1)
+    return device_mesh
+
+
+def test_scaled_mm(mesh: DeviceMesh, size=16):
+    device = mesh.device_type
+    fp8_dtype = torch.float8_e4m3fn
+    world_size = mesh.size()
+
+    x_fp32 = torch.rand(size, size, device=device)
+    y_fp32 = torch.eye(size, device=device).t()
+
+    placement_combs = (
+        (Shard(0), Replicate()),
+        (Replicate(), Shard(1)),
+        (Shard(1), Shard(0)),
+    )
+    expected_dt_out_shape = (
+        (size * world_size, size),
+        (size, size * world_size),
+        (size, size),
+    )
+    for idx, (lhs_placement, rhs_placement) in enumerate(placement_combs):
+        x_scale = tensor_to_scale(x_fp32, fp8_dtype).float()
+        y_scale = tensor_to_scale(y_fp32, fp8_dtype).float()
+
+        x_fp8 = Float8Tensor.to_float8(x_fp32, x_scale, fp8_dtype)
+        y_fp8 = Float8Tensor.to_float8(y_fp32, y_scale, fp8_dtype)
+
+        dist_x_fp8 = DTensor.from_local(x_fp8, mesh, [lhs_placement], run_check=False)
+        dist_y_fp8 = DTensor.from_local(y_fp8, mesh, [rhs_placement], run_check=False)
+
+        assert isinstance(dist_x_fp8.to_local(), Float8Tensor)
+        assert isinstance(dist_y_fp8.to_local(), Float8Tensor)
+        assert dist_x_fp8.to_local()._orig_dtype == torch.float32
+        out_fp8 = torch.mm(dist_x_fp8, dist_y_fp8)
+        assert out_fp8.shape == expected_dt_out_shape[idx], (idx, local_fp8_out.shape)
+
+        local_fp8_out = out_fp8.to_local()
+        # after mm the out dtype should be fp32
+        assert local_fp8_out.dtype == torch.float32
+
+
+if __name__ == "__main__":
+    # float8 only works on CUDA H100 so we only test cuda and we follow
+    # other test files to not use TestCase but instead just add the test
+    # cases in the main func.
+    device_mesh = setup_distributed()
+    test_scaled_mm(device_mesh)

--- a/test/test_dtensor.sh
+++ b/test/test_dtensor.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# terminate script on first error
+set -e
+
+NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/test_dtensor.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #210
* __->__ #209

This PR adds test to test the scaled_mm op working with DTensor.

Currently using the same style of test runner
compared to other tests in float8_experimental. We shall consider
switching to DTensorTestBase or MultiProcessTestCase in the repo but
didn't do it in this PR

Differential Revision: [D53731879](https://our.internmc.facebook.com/intern/diff/D53731879)