### PR TITLE
support DTensor redistribute to replicate (allgather)

### DIFF
--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -13,15 +13,11 @@ import os
 import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import init_device_mesh, DeviceMesh
-from torch.distributed._tensor import DTensor, distribute_tensor, Shard, Replicate
+from torch.distributed._tensor import DTensor, Shard, Replicate
 
-# from fairscale.nn.model_parallel.layers import ColumnParallelLinear, RowParallelLinear
 
-from float8_experimental.distributed_utils import _AllGatherFwSplitBw
-
-from float8_experimental.float8_python_api import mm_float8
 from float8_experimental.float8_tensor import Float8Tensor
-from float8_experimental.float8_utils import compute_error, tensor_to_scale
+from float8_experimental.float8_utils import tensor_to_scale
 
 
 def setup_distributed():
@@ -71,9 +67,36 @@ def test_scaled_mm(mesh: DeviceMesh, size=16):
         assert local_fp8_out.dtype == torch.float32
 
 
+def test_fp8_redistribute(mesh: DeviceMesh, size=16):
+    device = mesh.device_type
+    fp8_dtype = torch.float8_e4m3fn
+    world_size = mesh.size()
+
+    x_fp32 = torch.rand(size, size, device=device)
+
+    x_scale = tensor_to_scale(x_fp32, fp8_dtype).float()
+
+    x_fp8 = Float8Tensor.to_float8(x_fp32, x_scale, fp8_dtype)
+
+    dist_x_fp8 = DTensor.from_local(x_fp8, mesh, [Shard(0)], run_check=False)
+    out_dist = dist_x_fp8.redistribute(placements=[Replicate()])
+    assert out_dist.shape == (size * world_size, size)
+    assert out_dist.placements == (Replicate(),)
+    out_local = out_dist.to_local()
+    # after allgather the out shape should be replicate
+    assert out_local.shape == (size * world_size, size)
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+    if isinstance(out_local, AsyncCollectiveTensor):
+        out_local = out_local.wait()
+
+    assert isinstance(out_local, Float8Tensor)
+    assert out_local._data.dtype == fp8_dtype
+
+
 if __name__ == "__main__":
     # float8 only works on CUDA H100 so we only test cuda and we follow
     # other test files to not use TestCase but instead just add the test
     # cases in the main func.
     device_mesh = setup_distributed()
     test_scaled_mm(device_mesh)
+    test_fp8_redistribute(device_mesh)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #210
* #209

This PR adds support for fp8tensor allgather and make DTensor(Shard(0))
that holds a Float8Tensor to be able to do redistribute to replication

Differential Revision: [D53731878](https://our.internmc.facebook.com/intern/diff/D53731878)