### PR TITLE
Updates to sync_float_amax_history

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -138,23 +138,24 @@ class Float8LinearMixin(object):
         self.recipe = delayed_scaling_recipe
         history_len = self.recipe.history_len
 
-        self.register_always_float32_buffer("fp8_amax_x", torch.tensor(E4M3_MAX_POS))
+        self.register_always_float32_buffer("fp8_amax_x", torch.tensor([E4M3_MAX_POS]))
         self.register_always_float32_buffer(
             "fp8_amax_history_x", torch.zeros(history_len)
         )
-        self.register_always_float32_buffer("fp8_scale_x", torch.tensor(1.0))
-        self.register_always_float32_buffer("fp8_amax_w", torch.tensor(E4M3_MAX_POS))
+        self.register_always_float32_buffer("fp8_scale_x", torch.tensor([1.0]))
+        self.register_always_float32_buffer("fp8_amax_w", torch.tensor([E4M3_MAX_POS]))
         self.register_always_float32_buffer(
             "fp8_amax_history_w", torch.zeros(history_len)
         )
-        self.register_always_float32_buffer("fp8_scale_w", torch.tensor(1.0))
+        self.register_always_float32_buffer("fp8_scale_w", torch.tensor([1.0]))
         self.register_always_float32_buffer(
-            "fp8_amax_dL_dY", torch.tensor(E5M2_MAX_POS)
+            "fp8_amax_dL_dY", torch.tensor([E5M2_MAX_POS])
         )
         self.register_always_float32_buffer(
             "fp8_amax_history_dL_dY", torch.zeros(history_len)
         )
-        self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor(1.0))
+        self.register_always_float32_buffer("fp8_scale_dL_dY", torch.tensor([1.0]))
+
         # Whether to emulate the fp8 matmul logic in float32
         self.emulate = False
 

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -196,25 +196,25 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
         return
 
     # Loop over all fp8 layers and grab the needed tensors
-    fp8_amax_x_tensor_list = []
-    fp8_amax_w_tensor_list = []
-    fp8_amax_dL_dY_tensor_list = []
+    fp8_amax_x_tensor_list = [None] * len(fp8_layers)
+    fp8_amax_w_tensor_list = [None] * len(fp8_layers)
+    fp8_amax_dL_dY_tensor_list = [None] * len(fp8_layers)
 
-    fp8_x_amax_history_stack = []
-    fp8_w_amax_history_stack = []
-    fp8_dL_dY_amax_history_stack = []
+    fp8_x_amax_history_stack = [None] * len(fp8_layers)
+    fp8_w_amax_history_stack = [None] * len(fp8_layers)
+    fp8_dL_dY_amax_history_stack = [None] * len(fp8_layers)
 
     x_dtypes = set()
     scale_fn_recipes = set()
 
-    for child in fp8_layers:
-        fp8_amax_x_tensor_list.append(child.fp8_amax_x)
-        fp8_amax_w_tensor_list.append(child.fp8_amax_w)
-        fp8_amax_dL_dY_tensor_list.append(child.fp8_amax_dL_dY)
+    for idx, child in enumerate(fp8_layers):
+        fp8_amax_x_tensor_list[idx] = child.fp8_amax_x
+        fp8_amax_w_tensor_list[idx] = child.fp8_amax_w
+        fp8_amax_dL_dY_tensor_list[idx] = child.fp8_amax_dL_dY
 
-        fp8_x_amax_history_stack.append(child.fp8_amax_history_x)
-        fp8_w_amax_history_stack.append(child.fp8_amax_history_w)
-        fp8_dL_dY_amax_history_stack.append(child.fp8_amax_history_dL_dY)
+        fp8_x_amax_history_stack[idx] = child.fp8_amax_history_x
+        fp8_w_amax_history_stack[idx] = child.fp8_amax_history_w
+        fp8_dL_dY_amax_history_stack[idx] = child.fp8_amax_history_dL_dY
 
         x_dtypes.add(child.last_seen_input_dtype)
         scale_fn_recipes.add(child.recipe.scale_fn_name)

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -162,6 +162,7 @@ def get_float8_layers(model: torch.nn.Module):
     return fp8_layers
 
 
+@torch.no_grad()
 def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) -> None:
     """
     Manages the float8 amax and scale bookkeeping. In detail, it does the

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -210,10 +210,16 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
         scale_fn_recipes.add(child.recipe.scale_fn_name)
 
     # TODO This way to get the activation dtype is not ideal
-    assert len(x_dtypes) == 1, "All layers must have the same last seen input_dtype"
+    if len(x_dtypes) != 1:
+        raise ValueError(
+            f"All layers must have the same last seen input_dtype, got {x_dtypes}"
+        )
     x_dtype = next(iter(x_dtypes))
 
-    assert len(scale_fn_recipes) == 1, "All layers must have the same scale_fn recipe"
+    if len(scale_fn_recipes) != 1:
+        raise ValueError(
+            f"All layers must have the same scale_fn recipe, got {scale_fn_recipes}"
+        )
     scale_fn_recipe = next(iter(scale_fn_recipes))
 
     assert (

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -245,6 +245,8 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
             reduced_fp8_amax_w_tensor,
             reduced_fp8_amax_dL_dY_tensor,
         ) = torch.split(all_reduced_amax_tensor, len(fp8_amax_x_tensor_list))
+
+        # TODO foreach is not supported with AsyncCollectiveTensor
         for idx, child in enumerate(fp8_layers):
             child.fp8_amax_x.copy_(reduced_fp8_amax_tensor[idx])
             child.fp8_amax_w.copy_(reduced_fp8_amax_w_tensor[idx])

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -12,6 +12,8 @@ to simplify the product code.
 
 from typing import Optional, Tuple
 
+import float8_experimental.float8_aten_api  # noqa
+
 import torch
 from float8_experimental.float8_tensor import Float8Tensor
 

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -54,9 +54,7 @@ class FromFloat8ConstrFunc(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, tensor):
-        return (tensor._data.to(tensor._orig_dtype) / tensor._scale).to(
-            tensor._orig_dtype
-        )
+        return tensor._data.to(tensor._orig_dtype) / tensor._scale
 
     @staticmethod
     def backward(ctx, g):

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -54,7 +54,9 @@ class FromFloat8ConstrFunc(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, tensor):
-        return tensor._data.to(tensor._orig_dtype) / tensor._scale
+        return (tensor._data.to(tensor._orig_dtype) / tensor._scale).to(
+            tensor._orig_dtype
+        )
 
     @staticmethod
     def backward(ctx, g):

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -63,7 +63,7 @@ def amax_history_to_scale_stack(
         amax_stack = torch.max(amax_history, dim=1).values
         return amax_to_scale(amax_stack, float8_dtype, orig_dtype)
     raise NotImplementedError(
-        "Invalid history_to_scale_fn_type, only 'max' is supported."
+        f"Invalid history_to_scale_fn_type, only 'max' is supported. Got: {history_to_scale_fn_type}"
     )
 
 

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -23,7 +23,7 @@ EPS = 1e-12
 
 @torch.no_grad()
 def amax_to_scale(amax, float8_dtype, orig_dtype):
-    scale = torch.empty((), device=amax.device, dtype=torch.float32)
+    scale = torch.empty((1,), device=amax.device, dtype=torch.float32)
     if float8_dtype == torch.float8_e4m3fn:
         res = E4M3_MAX_POS / torch.clamp(amax, min=EPS)
     else:  # e5m2


### PR DESCRIPTION
# Summary

Update docs, make sure this is friendly to dynamo

### Perf

PyTorch Version | float8 Version | Eager Iterations per Second | Compile
-- | -- | -- | --
Nightly | Main | 1.15 it/s |  2.10 it/s
Nightly | This PR | 1.16 it/s | 2.27 it/s


Trace | Compile URL | Eager
-- | -- | --
This PR | https://fburl.com/753ztao4 |  https://fburl.com/34yftzao
Main |  https://fburl.com/a0gh9iof |  https://fburl.com/u9c4ilmp


### Things I have done/changed

#### Commit 1
- [x] We previously had an `fp8_classes` argument that would be passed in, this was to enable working with the separate TP/SP classes, since we plan to have Dtensor be the solution I am removing for now.
- [x] I put the child.amax_and_scale_synced module mutation under the enable_amax_init flag, this seemed to be causing graphbreaks cause of the module mutation

#### Commit 2

- [x] We previously had all the history buffers be scaler tensors. This meant that to construct the combined tensor we needed to call torch.Tensor which was causing a HtoD sync under torch.compile. I needed to added a single dimension of size 1 and pipe that through all the places.
- [x] Note that this meant we needed to update the to_hp to send back to original precision because [line](https://github.com/pytorch-labs/float8_experimental/pull/211/commits/f3630d05881f324eecb8e6e1837a3f487e77a7ff#diff-94b99416a4df6d75c548de330c1f71505e830b3afff114213d131cf2620597efR57-R59) the scale upcasts the _data tensor

#### Commit 3
- [x] Rewrote the sync function to do the torch.roll() on all the histories at once - side note not sure if this is more expensive than to clones since we really dont care about the wrapping behavior
- [x] Same for generating the new scales from the grouped histories

##### Things to do
- There is still two loops and those are for mutating the the actual module values, not sure if there is another way around this..
- Going to try the functional collectives

