### PR TITLE
Fixed memory leak in `swap_linear_with_float8_linear`

### DIFF
--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -103,6 +103,7 @@ def swap_linear_with_float8_linear(
     def post_order_traversal(
         module: nn.Module, module_name: str, parent_module: Optional[nn.Module]
     ):
+        nonlocal visited_modules
         for child_module_name, child_module in module.named_children():
             if child_module not in visited_modules:
                 visited_modules.add(child_module)
@@ -114,6 +115,9 @@ def swap_linear_with_float8_linear(
             setattr(parent_module, module_name, module_cls.from_float(module, emulate))
 
     post_order_traversal(root_module, "", None)
+    # Without this explicit `del`, this set only gets deleted upon an explicit
+    # garbage collection (not from when its refcount hits zero)
+    del visited_modules
     return root_module
 
 


### PR DESCRIPTION
After https://github.com/pytorch-labs/float8_experimental/pull/208, my memory unit test for FSDP + float8 was failing, where the module's original parameters were not being freed without an explicit `gc.collect()` before applying FSDP. After some debugging, I found that the `visited_modules` set was kept alive even after `swap_linear_with_float8_linear` returned until a garbage collection step (whether automatically by Python or `gc.collect()`). 

Repro:
```
import ctypes
import gc
import torch
import torch.nn as nn
from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
from float8_experimental.float8_linear import Float8Linear
from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear

model = nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16))
module_id = id(model[0])
float8_model = swap_linear_with_float8_linear(model, Float8DynamicLinear)
del model

print(ctypes.cast(module_id, ctypes.py_object).value)
print()
refs = gc.get_referrers(ctypes.cast(module_id, ctypes.py_object).value)
print(refs)
print([id(r) for r in refs])
```
If we additionally print `id(visited_modules)` in `swap_linear_with_float8_linear`, we see that the single referrer to the original `nn.Linear` module that should have been swapped with `Float8Linear` is that `visited_modules` set.

Without the explicit `del visited_modules`, `print(ctypes.cast(module_id, ctypes.py_object).value)` prints the `nn.Linear` (which it should not -- it should error since it has been garbage collected). With the `del visited_modules`, it errors as desired.