### PR TITLE
Added `use_activation_hooks: bool` to swap

### DIFF
--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -70,8 +70,10 @@ def _update_history_with_new_amax(new_amax, amax_history):
 def swap_linear_with_float8_linear(
     module: nn.Module,
     module_cls: Type[nn.Module],
-    emulate: bool = False,
+    *,
     skip_fqn_list: Optional[List[str]] = None,
+    emulate: bool = False,
+    use_activation_hooks: bool = False,
 ) -> nn.Module:
     """
     Replaces all instances of ``torch.nn.Linear`` in ``module`` with instances
@@ -80,9 +82,10 @@ def swap_linear_with_float8_linear(
     Args:
         module (torch.nn.Module): Module to modify.
         module_cls (Union[Type[Float8Linear], Type[Float8DynamicLinear]]): Float8 linear class for the swap.
-        emulate (bool, optional): Whether to emulate the fp8 matmul logic in fp32.
         skip_fqn_list (List[str], optional): If specified, a list of module FQNs to skip.
             Linear submodules of these skipped modules will also be skipped.
+        emulate (bool): Whether to emulate the fp8 matmul logic in fp32.
+        use_activation_hooks (bool): Whether to cast activations to fp8 using module hooks.
     """
     module_names_to_skip = set(skip_fqn_list or [])
     if isinstance(module, nn.Linear):
@@ -90,7 +93,9 @@ def swap_linear_with_float8_linear(
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        return module_cls.from_float(module, emulate)
+        return module_cls.from_float(
+            module, emulate=emulate, use_activation_hooks=use_activation_hooks
+        )
 
     # Mark all modules to skip as visited
     root_module = module
@@ -112,7 +117,10 @@ def swap_linear_with_float8_linear(
             assert (
                 parent_module is not None
             ), f"Linear root module should return early: {module}"
-            setattr(parent_module, module_name, module_cls.from_float(module, emulate))
+            float8linear_module = module_cls.from_float(
+                module, emulate=emulate, use_activation_hooks=use_activation_hooks
+            )
+            setattr(parent_module, module_name, float8linear_module)
 
     post_order_traversal(root_module, "", None)
     # Without this explicit `del`, this set only gets deleted upon an explicit

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -12,6 +12,8 @@ to simplify the product code.
 
 from typing import Optional, Tuple
 
+import float8_experimental.float8_aten_api  # noqa
+
 import torch
 from float8_experimental.float8_tensor import Float8Tensor
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -351,7 +351,7 @@ class TestFloat8LinearUtils(unittest.TestCase):
             [Float8Linear, Float8DynamicLinear], [True, False]
         ):
             module = nn.Linear(3, 3)
-            module = swap_linear_with_float8_linear(module, module_cls, emulate)
+            module = swap_linear_with_float8_linear(module, module_cls, emulate=emulate)
             self.assertIsInstance(module, module_cls)
             self.assertEqual(module.emulate, emulate)
 
@@ -365,7 +365,7 @@ class TestFloat8LinearUtils(unittest.TestCase):
                 AssertionError,
                 "Does not support a root nn.Linear with children",
             ):
-                swap_linear_with_float8_linear(module, module_cls, emulate)
+                swap_linear_with_float8_linear(module, module_cls, emulate=emulate)
 
     def test_swap_submodule_linears(self):
         class MLP(nn.Module):
@@ -378,7 +378,7 @@ class TestFloat8LinearUtils(unittest.TestCase):
             [Float8Linear, Float8DynamicLinear], [True, False]
         ):
             model = nn.Sequential(MLP(3), nn.Linear(3, 3), MLP(3))
-            model = swap_linear_with_float8_linear(model, module_cls, emulate)
+            model = swap_linear_with_float8_linear(model, module_cls, emulate=emulate)
             self.assertIsInstance(model[0].lin1, module_cls)
             self.assertIsInstance(model[0].lin2, module_cls)
             self.assertIsInstance(model[1], module_cls)
@@ -398,7 +398,7 @@ class TestFloat8LinearUtils(unittest.TestCase):
             model = nn.Sequential(MLP(3), nn.Linear(3, 3), MLP(3))
             skip_fqn_list = ["2", "0.lin2"]
             model = swap_linear_with_float8_linear(
-                model, module_cls, emulate, skip_fqn_list
+                model, module_cls, emulate=emulate, skip_fqn_list=skip_fqn_list
             )
             self.assertIsInstance(model[0].lin1, module_cls)
             self.assertNotIsInstance(model[0].lin2, module_cls)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #214

This PR exposes `use_activation_hooks` to `swap_linear_with_float8_linear`. I am not sure if we want this long-term. Are we going to consolidate to _always_ using activation hooks in the future (because we need it for DTensor (?))?

**Test Plan**
```
./test/test_everything.sh
```

Differential Revision: [D53780333](https://our.internmc.facebook.com/intern/diff/D53780333)