### PR TITLE
Used functional all-reduce for amax reduction

### DIFF
--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -77,7 +77,9 @@ def tensor_to_amax(x, distributed_reduction=False):
     if distributed_reduction and dist.is_initialized():
         # TODO: Dynamo rewriting synchronous in-place collectives does not work
         # at the moment. Use functional all-reduce to avoid graph break.
-        amax = dist._functional_collectives.all_reduce(amax, "MAX", list(range(dist.get_world_size())))
+        amax = dist._functional_collectives.all_reduce(
+            amax, "MAX", list(range(dist.get_world_size()))
+        )
         # dist.all_reduce(amax, op=dist.ReduceOp.MAX)
 
     return amax


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #217
* #216
* #215
* #214
* __->__ #219
* #220

Dynamo cannot remap the in-place max all-reduce to its functional equivalent on PyTorch `main` branch.
https://github.com/pytorch/pytorch/issues/120082