### PR TITLE
Set `amax_and_scale_synced` unconditionally

### DIFF
--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -281,7 +281,5 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
         child.fp8_scale_w.copy_(new_w_scales[idx])
         child.fp8_scale_dL_dY.copy_(new_dL_dY_scales[idx])
 
-        # 4. set a flag to signal amaxes/scales are ready
-        # We only update the flag if we know it will be checked by the modules
-        if fp8_config.enable_amax_init:
-            child.amax_and_scale_synced = True
+        # Set a flag to signal amaxes/scales are ready
+        child.amax_and_scale_synced = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #217
* #216
* #215
* #214
* #219
* __->__ #220

`Float8Linear.amax_and_scale_synced` is orthogonal to `config.enable_amax_init`.
- `enable_amax_init = False` skips the lazy initialization of amaxes and scales. Without this, the 1st iteration's amaxes will be the default (`E4M3_MAX_POS`).
- `amax_and_scale_synced` is checked every pre-forward regardless of `config.enable_amax_init`.

https://github.com/pytorch-labs/float8_experimental/blob/956195bbc3983594308e7ccd64bab204c457a7a8/float8_experimental/float8_linear.py#L266-L273