### PR TITLE
Added eager fp8 all-gather for dynamic scaling

### DIFF
--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -14,8 +14,6 @@ import torch
 from float8_experimental.float8_tensor import Float8Tensor, to_fp8_no_autograd
 from float8_experimental.float8_utils import tensor_to_scale
 
-aten = torch.ops.aten
-
 
 @torch._dynamo.allow_in_graph
 class NoopFwToFloat8E5M2Bw(torch.autograd.Function):

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -160,6 +160,7 @@ class Float8DynamicLinearWeightTensor(torch.Tensor):
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
+        # Define a standard `__torch_function__` that propagates state
         kwargs = kwargs or {}
 
         def wrap(cast_fn: Callable, emulate: bool, o: Any):

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -7,15 +7,12 @@
 A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 """
 
-import functools
-from typing import Any, Callable, cast, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
-import torch.nn as nn
 
 from float8_experimental.float8_tensor import Float8Tensor, to_fp8_no_autograd
 from float8_experimental.float8_utils import tensor_to_scale
-from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
 
@@ -133,13 +130,7 @@ class Float8DynamicLinear(torch.nn.Linear):
                 "bias": False,
             }
             new_mod = cls(use_activation_hooks, **super_kwargs)
-        if use_fp8_all_gather:
-            cast_fn = new_mod.cast_to_float8_e4m3fn
-            new_mod.weight = nn.Parameter(
-                Float8DynamicLinearWeightTensor(mod.weight, cast_fn, emulate)
-            )
-        else:
-            new_mod.weight = mod.weight
+        new_mod.weight = mod.weight
         new_mod.bias = mod.bias
         new_mod.emulate = emulate
         if new_mod.use_activation_hooks:
@@ -148,41 +139,25 @@ class Float8DynamicLinear(torch.nn.Linear):
             new_mod.register_forward_hook(
                 cast_grad_to_float8_e5m2_backward_forward_hook
             )
+        new_mod.use_fp8_all_gather = use_fp8_all_gather
         return new_mod
 
+    def fsdp_extensions(self) -> Dict[str, Any]:
+        if not self.use_fp8_all_gather:
+            return {}
 
-class Float8DynamicLinearWeightTensor(torch.Tensor):
-    def __new__(cls, tensor: torch.Tensor, cast_fn: Callable, emulate: bool):
-        return cls._make_subclass(cls, tensor, tensor.requires_grad)
+        from torch.distributed._composable.fsdp import FSDPTensorExtensions
 
-    def __init__(self, tensor: torch.Tensor, cast_fn: Callable, emulate: bool):
-        super().__init__()
-        self.cast_fn = cast_fn
-        self.emulate = emulate
+        weight_extensions = FSDPTensorExtensions(
+            self._fsdp_pre_all_gather, self._fsdp_post_all_gather
+        )
+        return {"weight": weight_extensions}
 
-    @classmethod
-    def __torch_function__(cls, func, types, args=(), kwargs=None):
-        # Define a standard `__torch_function__` that propagates state
-        kwargs = kwargs or {}
-
-        def wrap(cast_fn: Callable, emulate: bool, o: Any):
-            if isinstance(o, torch.Tensor) and not isinstance(o, cls):
-                return cls(o, cast_fn, emulate)
-            return o
-
-        with torch._C.DisableTorchFunctionSubclass():
-            if isinstance(args[0], cls):
-                out = func(*args, **kwargs)
-                return tree_map(
-                    functools.partial(wrap, args[0].cast_fn, args[0].emulate), out
-                )
-            return func(*args, **kwargs)
-
-    def fsdp_pre_all_gather(self) -> Tuple[Tuple[torch.Tensor, ...], Any]:
-        float8_tensor = self.cast_fn(self, reduce_amax=True)
+    def _fsdp_pre_all_gather(self, sharded_param: torch.Tensor):
+        float8_tensor = self.cast_to_float8_e4m3fn(sharded_param, reduce_amax=True)
         return (float8_tensor._data,), (float8_tensor._scale,)
 
-    def fsdp_post_all_gather(
+    def _fsdp_post_all_gather(
         self,
         all_gather_outputs: Tuple[torch.Tensor, ...],
         metadata: Any,
@@ -193,11 +168,11 @@ class Float8DynamicLinearWeightTensor(torch.Tensor):
         (data,) = all_gather_outputs
         (scale,) = metadata
         if out is not None:
-            out = cast(Float8Tensor, out)
+            assert isinstance(out, Float8Tensor), f"{type(out)}"
             assert (
                 data.untyped_storage().data_ptr()
                 == out._data.untyped_storage().data_ptr()
-            )
+            ), f"Expects out's data to be the all-gather output"
             out._scale = scale
             return
         return Float8Tensor(data, scale, param_dtype, self.emulate), (data,)

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -6,10 +6,16 @@
 """
 A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 """
+
+import functools
+from typing import Any, Callable, cast, Optional, Tuple, Union
+
 import torch
+import torch.nn as nn
 
 from float8_experimental.float8_tensor import Float8Tensor, to_fp8_no_autograd
 from float8_experimental.float8_utils import tensor_to_scale
+from torch.utils._pytree import tree_map
 
 
 @torch._dynamo.allow_in_graph
@@ -76,7 +82,11 @@ class Float8DynamicLinear(torch.nn.Linear):
         x_fp8 = x if self.use_activation_hooks else self.cast_to_float8_e4m3fn(x)
 
         # cast w to float8_e4m3fn
-        w_fp8 = self.cast_to_float8_e4m3fn(self.weight)
+        w_fp8 = (
+            self.weight
+            if isinstance(self.weight, Float8Tensor)  # cast by FSDP
+            else self.cast_to_float8_e4m3fn(self.weight)
+        )
 
         y = torch.nn.functional.linear(x_fp8, w_fp8, self.bias)
 
@@ -86,8 +96,10 @@ class Float8DynamicLinear(torch.nn.Linear):
 
         return y
 
-    def cast_to_float8_e4m3fn(self, inpt_tensor: torch.Tensor) -> Float8Tensor:
-        scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn)
+    def cast_to_float8_e4m3fn(
+        self, inpt_tensor: torch.Tensor, reduce_amax: bool = False
+    ) -> Float8Tensor:
+        scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn, reduce_amax)
         return Float8Tensor.to_float8(
             inpt_tensor, scale, torch.float8_e4m3fn, emulate=self.emulate
         )
@@ -97,7 +109,11 @@ class Float8DynamicLinear(torch.nn.Linear):
 
     @classmethod
     def from_float(
-        cls, mod, emulate: bool = False, use_activation_hooks: bool = False
+        cls,
+        mod,
+        emulate: bool = False,
+        use_activation_hooks: bool = False,
+        use_fp8_all_gather: bool = False,
     ) -> "Float8DynamicLinear":
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
@@ -106,6 +122,7 @@ class Float8DynamicLinear(torch.nn.Linear):
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
             use_activation_hooks (bool): whether to use activation hooks for casting to and from float8
+            use_fp8_all_gather (bool): whether to use fp8 all-gather for FSDP
         """
         with torch.device("meta"):
             super_kwargs = {
@@ -114,7 +131,13 @@ class Float8DynamicLinear(torch.nn.Linear):
                 "bias": False,
             }
             new_mod = cls(use_activation_hooks, **super_kwargs)
-        new_mod.weight = mod.weight
+        if use_fp8_all_gather:
+            cast_fn = new_mod.cast_to_float8_e4m3fn
+            new_mod.weight = nn.Parameter(
+                Float8DynamicLinearWeightTensor(mod.weight, cast_fn, emulate)
+            )
+        else:
+            new_mod.weight = mod.weight
         new_mod.bias = mod.bias
         new_mod.emulate = emulate
         if new_mod.use_activation_hooks:
@@ -124,3 +147,54 @@ class Float8DynamicLinear(torch.nn.Linear):
                 cast_grad_to_float8_e5m2_backward_forward_hook
             )
         return new_mod
+
+
+class Float8DynamicLinearWeightTensor(torch.Tensor):
+    def __new__(cls, tensor: torch.Tensor, cast_fn: Callable, emulate: bool):
+        return cls._make_subclass(cls, tensor, tensor.requires_grad)
+
+    def __init__(self, tensor: torch.Tensor, cast_fn: Callable, emulate: bool):
+        super().__init__()
+        self.cast_fn = cast_fn
+        self.emulate = emulate
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+
+        def wrap(cast_fn: Callable, emulate: bool, o: Any):
+            if isinstance(o, torch.Tensor) and not isinstance(o, cls):
+                return cls(o, cast_fn, emulate)
+            return o
+
+        with torch._C.DisableTorchFunctionSubclass():
+            if isinstance(args[0], cls):
+                out = func(*args, **kwargs)
+                return tree_map(
+                    functools.partial(wrap, args[0].cast_fn, args[0].emulate), out
+                )
+            return func(*args, **kwargs)
+
+    def fsdp_pre_all_gather(self) -> Tuple[Tuple[torch.Tensor, ...], Any]:
+        float8_tensor = self.cast_fn(self, reduce_amax=True)
+        return (float8_tensor._data,), (float8_tensor._scale,)
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs: Tuple[torch.Tensor, ...],
+        metadata: Any,
+        param_dtype: torch.dtype,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ) -> Union[Tuple[Float8Tensor, Tuple[torch.Tensor, ...]], None]:
+        (data,) = all_gather_outputs
+        (scale,) = metadata
+        if out is not None:
+            out = cast(Float8Tensor, out)
+            assert (
+                data.untyped_storage().data_ptr()
+                == out._data.untyped_storage().data_ptr()
+            )
+            out._scale = scale
+            return
+        return Float8Tensor(data, scale, param_dtype, self.emulate), (data,)

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -48,7 +48,7 @@ def _maybe_initialize_amaxes_scales_for_float8_cast(
     with torch.no_grad():
         # Note: we need to enable distributed reduction here in order
         # to match numerics between single GPU and multi GPU code
-        new_amax = tensor_to_amax(x, distributed_reduction=True)
+        new_amax = tensor_to_amax(x, reduce_amax=True)
         cur_amax.fill_(new_amax)
         amax_history[0] = new_amax
         new_scale = amax_history_to_scale(

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -93,6 +93,7 @@ def swap_linear_with_float8_linear(
     skip_fqn_list: Optional[List[str]] = None,
     emulate: bool = False,
     use_activation_hooks: bool = False,
+    use_fp8_all_gather: bool = False,
 ) -> nn.Module:
     """
     Replaces all instances of ``torch.nn.Linear`` in ``module`` with instances
@@ -105,16 +106,23 @@ def swap_linear_with_float8_linear(
             Linear submodules of these skipped modules will also be skipped.
         emulate (bool): Whether to emulate the fp8 matmul logic in fp32.
         use_activation_hooks (bool): Whether to cast activations to fp8 using module hooks.
+        use_fp8_all_gather (bool): Whether to use fp8 all-gather for FSDP.
     """
+    if use_fp8_all_gather and module_cls is not Float8DynamicLinear:
+        raise NotImplementedError(
+            f"use_fp8_all_gather=True can only be used with Float8DynamicLinear, not {module_cls}"
+        )
+    float8_kwargs = {"emulate": emulate, "use_activation_hooks": use_activation_hooks}
+    if use_fp8_all_gather:
+        # Only a kwarg for dynamic linear
+        float8_kwargs["use_fp8_all_gather"] = True
     module_names_to_skip = set(skip_fqn_list or [])
     if isinstance(module, nn.Linear):
         if len(list(module.children())) > 0:
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        return module_cls.from_float(
-            module, emulate=emulate, use_activation_hooks=use_activation_hooks
-        )
+        return module_cls.from_float(module, **float8_kwargs)
 
     # Mark all modules to skip as visited
     root_module = module
@@ -136,9 +144,7 @@ def swap_linear_with_float8_linear(
             assert (
                 parent_module is not None
             ), f"Linear root module should return early: {module}"
-            float8linear_module = module_cls.from_float(
-                module, emulate=emulate, use_activation_hooks=use_activation_hooks
-            )
+            float8linear_module = module_cls.from_float(module, **float8_kwargs)
             setattr(parent_module, module_name, float8linear_module)
 
     post_order_traversal(root_module, "", None)

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -68,7 +68,7 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False):
+def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.
@@ -81,7 +81,9 @@ def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False):
 
 
 @torch.no_grad()
-def tensor_to_scale(x: torch.Tensor, float8_dtype: torch.dtype, reduce_amax: bool = False):
+def tensor_to_scale(
+    x: torch.Tensor, float8_dtype: torch.dtype, reduce_amax: bool = False
+) -> torch.Tensor:
     amax = tensor_to_amax(x, reduce_amax=reduce_amax)
     return amax_to_scale(amax, float8_dtype, x.dtype)
 

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -68,21 +68,21 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x, distributed_reduction=False):
+def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False):
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will
     # happen elsewhere.
-    if distributed_reduction and dist.is_initialized():
+    if reduce_amax and dist.is_initialized():
         dist.all_reduce(amax, op=dist.ReduceOp.MAX)
 
     return amax
 
 
 @torch.no_grad()
-def tensor_to_scale(x, float8_dtype):
-    amax = tensor_to_amax(x)
+def tensor_to_scale(x: torch.Tensor, float8_dtype: torch.dtype, reduce_amax: bool = False):
+    amax = tensor_to_amax(x, reduce_amax=reduce_amax)
     return amax_to_scale(amax, float8_dtype, x.dtype)
 
 

--- a/test/test_everything.sh
+++ b/test/test_everything.sh
@@ -10,5 +10,6 @@ pytest test/test_compile.py
 ./test/test_fsdp_compile.sh
 ./test/test_tp.sh
 ./test/test_dtensor.sh
+pytest test/test_fsdp2/test_fsdp2_eager.py
 
 echo "all tests successful"

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -1,0 +1,124 @@
+import contextlib
+
+from typing import List, Optional, Type
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from float8_experimental import config
+from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
+from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear_utils import (
+    swap_linear_with_float8_linear,
+    sync_float8_amax_and_scale_history,
+)
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+)
+
+
+def init_transformer_with_fp8(
+    module_cls: Type,
+    *,
+    checkpoint_activations: bool = False,
+    use_activation_hooks: Optional[bool] = None,
+    use_fp8_all_gather: bool = False,
+):
+    torch.manual_seed(42)
+    args = ModelArgs(
+        n_layers=3,
+        dim=768,
+        n_heads=12,
+        dropout_p=0.0,
+        weight_tying=False,
+        checkpoint_activations=checkpoint_activations,
+    )
+    module = Transformer(args)
+    # Only dynamic linear supports activation hooks
+    use_hooks = use_activation_hooks or (module_cls is Float8DynamicLinear)
+    return swap_linear_with_float8_linear(
+        module, module_cls, emulate=True, use_activation_hooks=use_hooks
+    )
+
+
+@contextlib.contextmanager
+def enable_amax_init(enable: bool):
+    prev_value = config.enable_amax_init
+    config.enable_amax_init = enable
+    try:
+        yield
+    finally:
+        config.enable_amax_init = prev_value
+
+
+@contextlib.contextmanager
+def enable_pre_and_post_forward(enable: bool):
+    prev_value = config.enable_pre_and_post_forward
+    config.enable_pre_and_post_forward = enable
+    try:
+        yield
+    finally:
+        config.enable_pre_and_post_forward = prev_value
+
+
+def check_parity_no_mp(
+    test_cls,
+    ref_model: nn.Module,
+    ref_optim: torch.optim.Optimizer,
+    fsdp_model: nn.Module,
+    fsdp_optim: torch.optim.Optimizer,
+    local_inp: torch.Tensor,
+    module_cls: Type,
+):
+    for iter_idx in range(10):
+        losses: List[torch.Tensor] = []
+        for model, optim in ((ref_model, ref_optim), (fsdp_model, fsdp_optim)):
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            losses.append(model(local_inp).sum())
+            losses[-1].backward()
+            if model is ref_model:
+                for param in model.parameters():
+                    dist.all_reduce(param.grad)
+                    param.grad.div_(dist.get_world_size())
+            if module_cls is Float8Linear:
+                sync_float8_amax_and_scale_history(model)
+            optim.step()
+        test_cls.assertEqual(losses[0], losses[1])
+
+
+def check_parity_bf16_mp(
+    test_cls,
+    ref_model: nn.Module,
+    ref_model_bf16: nn.Module,
+    ref_optim: torch.optim.Optimizer,
+    fsdp_model: nn.Module,
+    fsdp_optim: torch.optim.Optimizer,
+    local_inp: torch.Tensor,
+    module_cls: Type,
+):
+    for iter_idx in range(10):
+        losses: List[torch.Tensor] = []
+        for model, optim in (
+            (ref_model_bf16, ref_optim),
+            (fsdp_model, fsdp_optim),
+        ):
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            losses.append(model(local_inp).sum())
+            losses[-1].backward()
+            if model is ref_model_bf16:
+                for param_bf16, param_fp32 in zip(
+                    ref_model_bf16.parameters(), ref_model.parameters()
+                ):
+                    dist.all_reduce(param_bf16.grad)
+                    param_bf16.grad.div_(dist.get_world_size())
+                    param_fp32.grad = param_bf16.grad.float()
+                    param_bf16.grad = None
+            if module_cls is Float8Linear:
+                sync_float8_amax_and_scale_history(model)
+            optim.step()
+            for param_fp32, param_bf16 in zip(
+                ref_model.parameters(), ref_model_bf16.parameters()
+            ):
+                param_bf16.detach().copy_(param_fp32)
+        test_cls.assertEqual(losses[0], losses[1])

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -1,65 +1,10 @@
-import contextlib
-
-from typing import List, Optional, Type
+from typing import List, Type
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from float8_experimental import config
-from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear
-from float8_experimental.float8_linear_utils import (
-    swap_linear_with_float8_linear,
-    sync_float8_amax_and_scale_history,
-)
-from torch.testing._internal.distributed._tensor.common_dtensor import (
-    ModelArgs,
-    Transformer,
-)
-
-
-def init_transformer_with_fp8(
-    module_cls: Type,
-    *,
-    checkpoint_activations: bool = False,
-    use_activation_hooks: Optional[bool] = None,
-    use_fp8_all_gather: bool = False,
-):
-    torch.manual_seed(42)
-    args = ModelArgs(
-        n_layers=3,
-        dim=768,
-        n_heads=12,
-        dropout_p=0.0,
-        weight_tying=False,
-        checkpoint_activations=checkpoint_activations,
-    )
-    module = Transformer(args)
-    # Only dynamic linear supports activation hooks
-    use_hooks = use_activation_hooks or (module_cls is Float8DynamicLinear)
-    return swap_linear_with_float8_linear(
-        module, module_cls, emulate=True, use_activation_hooks=use_hooks
-    )
-
-
-@contextlib.contextmanager
-def enable_amax_init(enable: bool):
-    prev_value = config.enable_amax_init
-    config.enable_amax_init = enable
-    try:
-        yield
-    finally:
-        config.enable_amax_init = prev_value
-
-
-@contextlib.contextmanager
-def enable_pre_and_post_forward(enable: bool):
-    prev_value = config.enable_pre_and_post_forward
-    config.enable_pre_and_post_forward = enable
-    try:
-        yield
-    finally:
-        config.enable_pre_and_post_forward = prev_value
+from float8_experimental.float8_linear_utils import sync_float8_amax_and_scale_history
 
 
 def check_parity_no_mp(

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -1,0 +1,437 @@
+import copy
+import threading
+import unittest
+from typing import Any, List
+
+import torch
+import torch._dynamo.testing
+import torch.distributed as dist
+import torch.nn as nn
+from float8_experimental.float8_dynamic_linear import (
+    Float8DynamicLinear,
+    Float8DynamicLinearWeightTensor,
+)
+from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
+from test_fsdp2_common import check_parity_bf16_mp, check_parity_no_mp
+from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
+from torch.distributed._tensor import DTensor
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+    FSDPTestMultiThread,
+    MLP,
+    patch_all_gather,
+)
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+    TransformerBlock,
+)
+
+
+class TestFloat8Common:
+    def _broadcast_module(self, module: nn.Module) -> None:
+        # Broadcast for multi-threaded process group tests since seed is per
+        # process, not per thread
+        for param in module.parameters():
+            dist.broadcast(param, src=0)
+
+    def _init_single_module(self) -> nn.Module:
+        torch.manual_seed(42)
+        module = nn.Linear(16, 16, device="cuda")
+        self._broadcast_module(module)
+        return module
+
+    def _init_multi_module(self) -> nn.Module:
+        torch.manual_seed(42)
+        module = nn.Sequential(*[MLP(16, device="cuda") for _ in range(3)])
+        self._broadcast_module(module)
+        return module
+
+    def _init_transformer(self, weight_tying: bool) -> nn.Module:
+        torch.manual_seed(42)
+        args = ModelArgs(
+            n_layers=3, dim=768, n_heads=12, dropout_p=0.0, weight_tying=weight_tying
+        )
+        module = Transformer(args).cuda()
+        self._broadcast_module(module)
+        return module
+
+    def _get_local_inp(self, dtype: torch.dtype = torch.float32):
+        torch.manual_seed(42)
+        global_inp = torch.randn((16 * self.world_size, 16), device="cuda", dtype=dtype)
+        dist.broadcast(global_inp, src=0)
+        return global_inp.view(self.world_size, -1)[self.rank].view(16, 16)
+
+    def swap_linear_with_dynamic(self, module: nn.Module, **kwargs: Any) -> nn.Module:
+        if "use_activation_hooks" in kwargs:
+            assert kwargs["use_activation_hooks"] is True
+            del kwargs["use_activation_hooks"]
+        # Always use activation hooks since we need it to compose with DTensor
+        # tensor parallelism
+        return swap_linear_with_float8_linear(
+            module, Float8DynamicLinear, use_activation_hooks=True, **kwargs
+        )
+
+
+class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
+    @property
+    def world_size(self) -> int:
+        return min(torch.cuda.device_count(), 2)
+
+    @skip_if_lt_x_gpu(2)
+    def test_transformer_parity_dynamic(self):
+        for use_fp8_all_gather in [False, True]:
+            self._test_transformer_parity_dynamic(use_fp8_all_gather)
+
+    def _test_transformer_parity_dynamic(self, use_fp8_all_gather: bool):
+        # NOTE: Weight-tying does not compose with fp8 all-gather because the
+        # embedding weight and output linear weight are tied but only the
+        # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
+        # fp8 for that tied weight, incorrectly using fp8 for the embedding.
+        weight_tying = not use_fp8_all_gather
+        module = self._init_transformer(weight_tying=weight_tying)
+        ref_module = copy.deepcopy(module)
+        ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
+        module = self.swap_linear_with_dynamic(
+            module, use_fp8_all_gather=use_fp8_all_gather
+        )
+        for submodule in module.modules():
+            if isinstance(submodule, TransformerBlock):
+                fully_shard(submodule)
+        fully_shard(module)
+        ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+        optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+        local_inp = torch.randint(
+            0, ref_module.tok_embeddings.weight.size(0), (16, 16), device="cuda"
+        )
+        check_parity_no_mp(
+            self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_transformer_memory(self):
+        """Tests peak active memory in the forward and backward passes."""
+        for use_fp8_all_gather in [False, True]:
+            self._test_transformer_memory(use_fp8_all_gather)
+
+    def _test_transformer_memory(self, use_fp8_all_gather: bool):
+        torch.manual_seed(42)
+        # Pre-run a linear forward (gemm and bias) and backward (gemm) to
+        # allocate the cuBLAS workspaces before measuring the memory usage
+        # since the workspace size can differ between hardwares
+        lin = torch.nn.Linear(768, 768, device="cuda")
+        inp = torch.randn(1, 768, device="cuda")
+        lin(inp).sum().backward()
+        torch.cuda.empty_cache()
+        base_mem_mb = self._get_peak_active_memory_mb()
+
+        vocab_size = 32
+        model_args = ModelArgs(
+            vocab_size=vocab_size,
+            n_layers=3,
+            dim=768,
+            n_heads=12,
+            weight_tying=False,
+        )
+        model = Transformer(model_args)
+        # Emulate the fp8 matmul to bypass the scaled matmul op's divisibility
+        # requirement to use a smaller activation size
+        model = self.swap_linear_with_dynamic(
+            model, use_fp8_all_gather=use_fp8_all_gather, emulate=True
+        )
+        model_unsharded_numel = sum(p.numel() for p in model.parameters())
+        model_sharded_numel = (model_unsharded_numel + 1) // 2
+        block_lin_weight_numel = 0
+        block_other_numel = 0
+        for module in model.layers[0].modules():
+            for param in module.parameters(recurse=False):
+                if isinstance(module, nn.Linear):
+                    block_lin_weight_numel += param.numel()
+                else:
+                    block_other_numel += param.numel()
+        non_block_numel = round(
+            sum(p.numel() for p in model.tok_embeddings.parameters())
+            + sum(p.numel() for p in model.pos_embeddings.parameters())
+            + sum(p.numel() for p in model.norm.parameters())
+            + sum(p.numel() for p in model.output.parameters())
+        )
+        for module in model.modules():
+            if isinstance(module, TransformerBlock):
+                fully_shard(module)
+        fully_shard(model)
+
+        # Init: Each module is moved to GPU before sharding parameters
+        peak_mem_mb = self._get_peak_active_memory_mb()
+        curr_mem_mb = self._get_curr_active_memory_mb()
+        init_mem_mb = (
+            (model_sharded_numel + block_lin_weight_numel + block_other_numel) * 4 / 1e6
+        )
+        # Allow for some buffer for the peak memory since original parameters
+        # are not freed until a `fully_shard` call returns
+        buffer_mb = 4
+        self.assertLessEqual(peak_mem_mb - base_mem_mb, init_mem_mb + buffer_mb)
+        self.assertLessEqual(curr_mem_mb - base_mem_mb, init_mem_mb)
+
+        # Use a small input to minimize activation memory usage
+        inp = torch.randint(0, vocab_size, (1, 4), device="cuda")
+
+        # Forward:
+        loss = model(inp)
+        mem_mb = self._get_peak_active_memory_mb()
+        # Allow for some buffer for fragmentation/activations (where this
+        # number is kept much smaller than the actual memory usage, which is on
+        # the order of 100-200+ MB)
+        buffer_mb = 16
+        if use_fp8_all_gather:
+            # Non-block parameters (fp32), 3x block non-linear-weight
+            # parameters (fp32) and block linear-weight parameters (fp8)
+            # (current all-gather, copy-out, and next all-gather), and other
+            expected_mem_mb = (
+                (non_block_numel * 4)
+                + 3 * (block_lin_weight_numel + block_other_numel * 4)
+            ) / 1e6 + buffer_mb
+        else:
+            # Non-block parameters (fp32), 3x block parameters (fp32)
+            # (current all-gather, copy-out, and next all-gather), Nx block
+            # linear-weight parameters (fp8) for N blocks (saved by autograd),
+            # and other
+            expected_mem_mb = (
+                (non_block_numel + 3 * (block_lin_weight_numel + block_other_numel)) * 4
+                + model_args.n_layers * block_lin_weight_numel
+            ) / 1e6 + buffer_mb
+        # Sharded parameters
+        expected_mem_mb += model_sharded_numel * 4 / 1e6
+        self.assertLessEqual(mem_mb, expected_mem_mb + base_mem_mb)
+
+        # Backward:
+        loss.sum().backward()
+        mem_mb = self._get_peak_active_memory_mb()
+        if use_fp8_all_gather:
+            # Non-block parameters (fp32), 2x block non-linear weight
+            # parameters (fp32) and block linear-weight parameters (fp8)
+            # (current copy-out and next all-gather), 1x block gradients (fp32)
+            expected_mem_mb = (
+                (non_block_numel * 4)
+                + 2 * (block_lin_weight_numel + block_other_numel * 4)
+                + 1 * (block_lin_weight_numel + block_other_numel) * 4
+            ) / 1e6 + buffer_mb
+        else:
+            # Non-block parameters (fp32), 3x block parameters (fp32) (current
+            # copy-out, next all-gather, current gradients)
+            expected_mem_mb = (
+                non_block_numel + 3 * (block_lin_weight_numel + block_other_numel) * 4
+            ) * 4 / 1e6 + buffer_mb
+        # 2x sharded parameters/gradients
+        expected_mem_mb += 2 * model_sharded_numel * 4 / 1e6
+        self.assertLessEqual(mem_mb, expected_mem_mb + base_mem_mb)
+
+    def _get_peak_active_memory_mb(self) -> int:
+        mem_stats = torch.cuda.memory_stats()
+        return round(mem_stats["active_bytes.all.peak"] / 1e6)
+
+    def _get_curr_active_memory_mb(self) -> int:
+        mem_stats = torch.cuda.memory_stats()
+        return round(mem_stats["active_bytes.all.current"] / 1e6)
+
+
+class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_weight_subclass_dynamic(self):
+        """
+        Tests that the dynamic linear weight is of the subclass type when
+        enabling fp8 all-gather.
+        """
+        tensor_cls = Float8DynamicLinearWeightTensor
+
+        # Check for a single FSDP paramter group
+        module_fp32 = self._init_single_module()
+        module = self.swap_linear_with_dynamic(module_fp32, use_fp8_all_gather=True)
+        self.assertIsInstance(module.weight, tensor_cls)
+        fully_shard(module)
+        for param_name, param in module.named_parameters():
+            self.assertIsInstance(param, DTensor)
+            if "weight" in param_name:
+                self.assertIsInstance(param.to_local(), tensor_cls)
+
+        # Check for multiple FSDP paramter groups
+        module = self._init_multi_module()
+        module = self.swap_linear_with_dynamic(module, use_fp8_all_gather=True)
+        for param_name, param in module.named_parameters():
+            if "weight" in param_name:
+                self.assertIsInstance(param, tensor_cls)
+        for mlp in module:
+            fully_shard(mlp)
+        fully_shard(module)
+        for param_name, param in module.named_parameters():
+            self.assertIsInstance(param, DTensor)
+            if "weight" in param_name:
+                self.assertIsInstance(param.to_local(), tensor_cls)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp8_fp32_all_gather_dynamic_comm_size(self):
+        """
+        Tests that fp8 all-gather with dynamic scaling communicates the
+        expected number of bytes.
+        """
+        orig_all_gather = dist.all_gather_into_tensor
+        all_gather_sizes: List[int] = []
+        lock = threading.Lock()
+
+        def all_gather(*args: Any, **kwargs: Any):
+            nonlocal all_gather_sizes
+            if len(args) > 0:
+                output = args[0]
+            elif "output_tensor" in kwargs:
+                output = kwargs["output_tensor"]
+            else:
+                raise AssertionError(
+                    f"Cannot get all-gather output from\nargs: {args}\nkwargs: {kwargs}"
+                )
+            with lock:
+                all_gather_sizes.append(output.numel() * output.itemsize)
+            return orig_all_gather(*args, **kwargs)
+
+        def get_expected_all_gather_size(module: nn.Module):
+            size = 0
+            for param_name, param in module.named_parameters():
+                bytes_per_numel = 1 if "weight" in param_name else param.itemsize
+                size += param.numel() * bytes_per_numel
+            return size
+
+        # - Check for a single FSDP parameter group
+        module_fp32 = self._init_single_module()
+        ref_module = copy.deepcopy(module_fp32)
+        module = self.swap_linear_with_dynamic(module_fp32, use_fp8_all_gather=True)
+        fully_shard(module)
+        local_inp = self._get_local_inp()
+        expected_all_gather_size = get_expected_all_gather_size(ref_module)
+        with patch_all_gather(all_gather):
+            out = module(local_inp)
+        # For MPTG, one rank runs all all-gathers, each of the same size
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size)
+            self.assertEqual(
+                all_gather_sizes, [expected_all_gather_size] * self.world_size
+            )
+        all_gather_sizes.clear()
+        # Force-reshard the module to check the backward all-gather
+        module.reshard()
+        with patch_all_gather(all_gather):
+            out.sum().backward()
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size)
+            self.assertEqual(
+                all_gather_sizes, [expected_all_gather_size] * self.world_size
+            )
+        all_gather_sizes.clear()
+
+        # - Check for multiple FSDP parameter groups
+        module = self._init_multi_module()
+        ref_module = copy.deepcopy(module)
+        module = self.swap_linear_with_dynamic(module, use_fp8_all_gather=True)
+        for submodule in module:
+            fully_shard(submodule)
+        fully_shard(module)
+        expected_all_gather_sizes = (
+            get_expected_all_gather_size(submodule) for submodule in module
+        )
+        with patch_all_gather(all_gather):
+            out = module(local_inp)
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size * len(module))
+            self.assertEqual(
+                all_gather_sizes,
+                [s for s in expected_all_gather_sizes for _ in range(self.world_size)],
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp32_fp8_single_module_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with fp8 computation with a
+        single module/FSDP communication group.
+        """
+        for use_fp8_all_gather in [False, True]:
+            module_fp32 = self._init_single_module()
+            ref_module = self.swap_linear_with_dynamic(copy.deepcopy(module_fp32))
+            ref_module = ref_module.cuda()
+            module = self.swap_linear_with_dynamic(
+                module_fp32, use_fp8_all_gather=use_fp8_all_gather
+            )
+            fully_shard(module)
+            ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+            optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+            local_inp = self._get_local_inp()
+            check_parity_no_mp(
+                self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp32_fp8_multi_module_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with fp8 computation with
+        multiple modules/FSDP communication groups.
+        """
+        for use_fp8_all_gather in [False, True]:
+            module = self._init_multi_module()
+            ref_module = copy.deepcopy(module)
+            ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
+            module = self.swap_linear_with_dynamic(
+                module, use_fp8_all_gather=use_fp8_all_gather
+            )
+            for submodule in module:
+                fully_shard(submodule)
+            fully_shard(module)
+            ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+            optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+            local_inp = self._get_local_inp()
+            check_parity_no_mp(
+                self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_bf16_mp_fp8_dynamic_multi_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with FSDP's bf16 mixed
+        precision and fp8 computation with multiple modules/FSDP communication
+        groups. Parameters are all-gathered in bf16 before being cast to fp8.
+        """
+        # NOTE: We cannot test easily with fp8 all-gather because then the scale
+        # is computed using the fp32 sharded parameters, not the bf16 unsharded
+        # parameters, changing the numerics.
+        module = self._init_multi_module()
+        ref_module_bf16 = copy.deepcopy(module).to(torch.bfloat16)
+        ref_module_bf16 = swap_linear_with_float8_linear(
+            ref_module_bf16,
+            Float8DynamicLinear,
+            emulate=True,
+            use_activation_hooks=True,
+        )
+        ref_module_fp32 = copy.deepcopy(module).cuda()
+        module = swap_linear_with_float8_linear(
+            module, Float8DynamicLinear, emulate=True, use_activation_hooks=True
+        )
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
+        for mlp in module:
+            fully_shard(mlp, mp_policy=mp_policy)
+        fully_shard(module, mp_policy=mp_policy)
+        check_parity_bf16_mp(
+            self,
+            ref_module_fp32,
+            ref_module_bf16,
+            torch.optim.Adam(ref_module_fp32.parameters(), lr=1e-2),
+            module,
+            torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True),
+            self._get_local_inp(torch.bfloat16),
+            Float8DynamicLinear,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -369,7 +369,13 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
             local_inp = self._get_local_inp()
             check_parity_no_mp(
-                self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+                self,
+                ref_module,
+                ref_optim,
+                module,
+                optim,
+                local_inp,
+                Float8DynamicLinear,
             )
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
@@ -392,7 +398,13 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
             local_inp = self._get_local_inp()
             check_parity_no_mp(
-                self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+                self,
+                ref_module,
+                ref_optim,
+                module,
+                optim,
+                local_inp,
+                Float8DynamicLinear,
             )
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -32,34 +32,34 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TestFloat8Common:
-    def _broadcast_module(self, module: nn.Module) -> None:
+    def broadcast_module(self, module: nn.Module) -> None:
         # Broadcast for multi-threaded process group tests since seed is per
         # process, not per thread
         for param in module.parameters():
             dist.broadcast(param, src=0)
 
-    def _init_single_module(self) -> nn.Module:
+    def init_single_module(self) -> nn.Module:
         torch.manual_seed(42)
         module = nn.Linear(16, 16, device="cuda")
-        self._broadcast_module(module)
+        self.broadcast_module(module)
         return module
 
-    def _init_multi_module(self) -> nn.Module:
+    def init_multi_module(self) -> nn.Module:
         torch.manual_seed(42)
         module = nn.Sequential(*[MLP(16, device="cuda") for _ in range(3)])
-        self._broadcast_module(module)
+        self.broadcast_module(module)
         return module
 
-    def _init_transformer(self, weight_tying: bool) -> nn.Module:
+    def init_transformer(self, weight_tying: bool) -> nn.Module:
         torch.manual_seed(42)
         args = ModelArgs(
             n_layers=3, dim=768, n_heads=12, dropout_p=0.0, weight_tying=weight_tying
         )
         module = Transformer(args).cuda()
-        self._broadcast_module(module)
+        self.broadcast_module(module)
         return module
 
-    def _get_local_inp(self, dtype: torch.dtype = torch.float32):
+    def get_local_inp(self, dtype: torch.dtype = torch.float32):
         torch.manual_seed(42)
         global_inp = torch.randn((16 * self.world_size, 16), device="cuda", dtype=dtype)
         dist.broadcast(global_inp, src=0)
@@ -92,7 +92,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
         # fp8 for that tied weight, incorrectly using fp8 for the embedding.
         weight_tying = not use_fp8_all_gather
-        module = self._init_transformer(weight_tying=weight_tying)
+        module = self.init_transformer(weight_tying=weight_tying)
         ref_module = copy.deepcopy(module)
         ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
         module = self.swap_linear_with_dynamic(
@@ -251,7 +251,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         tensor_cls = Float8DynamicLinearWeightTensor
 
         # Check for a single FSDP paramter group
-        module_fp32 = self._init_single_module()
+        module_fp32 = self.init_single_module()
         module = self.swap_linear_with_dynamic(module_fp32, use_fp8_all_gather=True)
         self.assertIsInstance(module.weight, tensor_cls)
         fully_shard(module)
@@ -261,7 +261,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
                 self.assertIsInstance(param.to_local(), tensor_cls)
 
         # Check for multiple FSDP paramter groups
-        module = self._init_multi_module()
+        module = self.init_multi_module()
         module = self.swap_linear_with_dynamic(module, use_fp8_all_gather=True)
         for param_name, param in module.named_parameters():
             if "weight" in param_name:
@@ -306,11 +306,11 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             return size
 
         # - Check for a single FSDP parameter group
-        module_fp32 = self._init_single_module()
+        module_fp32 = self.init_single_module()
         ref_module = copy.deepcopy(module_fp32)
         module = self.swap_linear_with_dynamic(module_fp32, use_fp8_all_gather=True)
         fully_shard(module)
-        local_inp = self._get_local_inp()
+        local_inp = self.get_local_inp()
         expected_all_gather_size = get_expected_all_gather_size(ref_module)
         with patch_all_gather(all_gather):
             out = module(local_inp)
@@ -333,7 +333,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         all_gather_sizes.clear()
 
         # - Check for multiple FSDP parameter groups
-        module = self._init_multi_module()
+        module = self.init_multi_module()
         ref_module = copy.deepcopy(module)
         module = self.swap_linear_with_dynamic(module, use_fp8_all_gather=True)
         for submodule in module:
@@ -358,7 +358,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         single module/FSDP communication group.
         """
         for use_fp8_all_gather in [False, True]:
-            module_fp32 = self._init_single_module()
+            module_fp32 = self.init_single_module()
             ref_module = self.swap_linear_with_dynamic(copy.deepcopy(module_fp32))
             ref_module = ref_module.cuda()
             module = self.swap_linear_with_dynamic(
@@ -367,7 +367,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             fully_shard(module)
             ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
-            local_inp = self._get_local_inp()
+            local_inp = self.get_local_inp()
             check_parity_no_mp(
                 self,
                 ref_module,
@@ -385,7 +385,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         multiple modules/FSDP communication groups.
         """
         for use_fp8_all_gather in [False, True]:
-            module = self._init_multi_module()
+            module = self.init_multi_module()
             ref_module = copy.deepcopy(module)
             ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
             module = self.swap_linear_with_dynamic(
@@ -396,7 +396,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             fully_shard(module)
             ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
-            local_inp = self._get_local_inp()
+            local_inp = self.get_local_inp()
             check_parity_no_mp(
                 self,
                 ref_module,
@@ -417,7 +417,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         # NOTE: We cannot test easily with fp8 all-gather because then the scale
         # is computed using the fp32 sharded parameters, not the bf16 unsharded
         # parameters, changing the numerics.
-        module = self._init_multi_module()
+        module = self.init_multi_module()
         ref_module_bf16 = copy.deepcopy(module).to(torch.bfloat16)
         ref_module_bf16 = swap_linear_with_float8_linear(
             ref_module_bf16,
@@ -440,7 +440,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             torch.optim.Adam(ref_module_fp32.parameters(), lr=1e-2),
             module,
             torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True),
-            self._get_local_inp(torch.bfloat16),
+            self.get_local_inp(torch.bfloat16),
             Float8DynamicLinear,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #231
* #230
* __->__ #229

This PR is not ready to land yet since the FSDP-side changes to add the extension point has not landed.

**Overview**
This PR adds fp8 all-gather for dynamic scaling, only concerning eager mode.
- We prioritize dynamic scaling over delayed scaling due to internal priorities based on initial experiments.
- ~~The approach for fp8 all-gather is based on making the `weight` into a tensor subclass that implements pre- and post-all-gather transforms.~~ The new short-term approach is to define a special method on `Float8DynamicLinear` to give the pre/post-all-gather methods.
- This PR checks numeric correctness and memory for both using and not using fp8 all-gather with FSDP2 (per-parameter FSDP).

This PR adds ~27 seconds of test time on H100.

**Details on fp8 all-gather**
- ~~For fp8 all-gather, we change `Float8DynamicLinear.weight` into a tensor subclass `Float8DynamicLinearWeightTensor` that implements `fsdp_pre_all_gather()` and `fsdp_post_all_gather()`.~~
- ~~Since implementing those methods requires some state, we must override `__torch_function__` to propagate that state when calling torch functions (e.g. `detach`).~~
- The pre-all-gather casts to fp8 and returns the `torch.Tensor` data and some metadata. The post-all-gather wraps the all-gathered `torch.Tensor` data into `Float8Tensor` using the metadata.

For performant fp8 all-gather with dynamic scaling, we want:
- To all-gather all amaxes in one all-reduce
- To compile this computation of amaxes and scales

We will explore `compile` and performance in subsequent PRs.
