### PR TITLE
Add in pre-commit config and some more CI/CD

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,9 +27,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install -e .'[dev]'
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        flake8
+        ruff check .
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,35 @@
+# Basic flak8 + pytest workflow for Python 3.10
+
+name: Python Lint and Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install -e .'[dev]'
+    - name: Lint with flake8
+      run: |
+        flake8
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,6 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install -e .'[dev]'
+        pip install -e .'[test]'
     - name: Lint with ruff
       run: |
         ruff check .

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,4 +33,4 @@ jobs:
         ruff check .
     - name: Test with pytest
       run: |
-        pytest
+        ./test/test_everything.sh

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Lint with ruff
       run: |
         ruff check .
-    - name: Test with pytest
+    - name: Running Tests
       run: |
         ./test/test_everything.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,15 +17,6 @@ repos:
     -   id: end-of-file-fixer
         exclude: '^(.*\.svg)$'
 
--   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
-    hooks:
-    -   id: insert-license
-        files: \.py$
-        args:
-        - --license-filepath
-        - docs/license_header.txt
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,12 @@ repos:
         - --license-filepath
         - docs/license_header.txt
 
--   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.3.0
     hooks:
-    -   id: flake8
-        additional_dependencies: [flake8-pyproject]
+        # Run the linter.
+        - id: ruff
 
 -   repo: https://github.com/omnilib/ufmt
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+exclude: 'build'
+
+default_language_version:
+    python: python3
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 6306a48f7dae5861702d573c9c247e4e9498e867
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-ast
+    -   id: check-merge-conflict
+    -   id: no-commit-to-branch
+        args: ['--branch=main']
+    -   id: check-added-large-files
+        args: ['--maxkb=500']
+    -   id: end-of-file-fixer
+        exclude: '^(.*\.svg)$'
+
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+    -   id: insert-license
+        files: \.py$
+        args:
+        - --license-filepath
+        - docs/license_header.txt
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [flake8-pyproject]
+
+-   repo: https://github.com/omnilib/ufmt
+    rev: v2.3.0
+    hooks:
+    -   id: ufmt
+        additional_dependencies:
+          - black == 23.3.0
+          - usort == 1.0.6

--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -222,8 +222,7 @@ def main(
     print(data_pd_simple)
 
     sweep_path = sweep_path.with_suffix(".csv")
-    with open(sweep_path, mode="w") as file:
-        data_pd.to_csv(sweep_path)
+    data_pd.to_csv(sweep_path)
 
 
 def invoke_main() -> None:

--- a/benchmarks/bench_matmul.py
+++ b/benchmarks/bench_matmul.py
@@ -66,7 +66,6 @@ def run(n_limit: Optional[int] = None):
     results = []
 
     name_to_shapes = name_to_shapes_70b
-    bsz_and_seq_len = ((4, 4096),)
     dtypes = torch.bfloat16, torch.float16
 
     for idx, (dtype, (name, (K, N))) in enumerate(

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -76,7 +76,6 @@ def fsdp_main(rank, world_size, args):
     base_dtype, input_global, compile = args
 
     # basic distributed data sampling
-    bsz_global = input_global.shape[0]
     assert B % world_size == 0
     bsz_local_start = int(rank / world_size * B)
     bsz_local_end = int((rank + 1) / world_size * B)

--- a/float8_experimental/distributed_utils.py
+++ b/float8_experimental/distributed_utils.py
@@ -58,7 +58,6 @@ def _gather_along_first_dim(input_: torch.Tensor):
 
 def _reduce_scatter(ctx: Any, input_: torch.Tensor):
     group = get_model_parallel_group()
-    rank = torch.distributed.get_rank(group)
     world_size = torch.distributed.get_world_size(group)
 
     assert input_.shape[0] % world_size == 0

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -8,8 +8,6 @@ import logging
 from enum import auto, Enum
 from typing import List, Optional, Type
 
-import float8_experimental.config as fp8_config
-
 import torch
 import torch.distributed as dist
 import torch.nn as nn

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -14,6 +14,7 @@ from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
 c10d_functional = torch.ops.c10d_functional
+_c10d_functional = torch.ops._c10d_functional
 FLOAT8_OPS_TABLE: Dict[Any, Any] = {}
 
 
@@ -148,7 +149,12 @@ def autocast_to_copy(aten_op, args, kwargs=None):
     )
 
 
-@implements([c10d_functional.all_gather_into_tensor.default])
+@implements(
+    [
+        c10d_functional.all_gather_into_tensor.default,
+        _c10d_functional.all_gather_into_tensor.default,
+    ]
+)
 def allgather_fp8(aten_op, args, kwargs=None):
     """
     override funcol with FP8 handling
@@ -166,7 +172,7 @@ def allgather_fp8(aten_op, args, kwargs=None):
     return Float8Tensor(fp8_out, fp8_input._scale, fp8_input._orig_dtype)
 
 
-@implements([c10d_functional.wait_tensor.default])
+@implements([c10d_functional.wait_tensor.default, _c10d_functional.wait_tensor.default])
 def wait_tensor_fp8(aten_op, args, kwargs=None):
     fp8_input = args[0]
     assert isinstance(fp8_input, Float8Tensor)

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -7,11 +7,7 @@ from typing import Dict, Optional
 
 import torch
 
-from float8_experimental.float8_utils import (
-    tensor_to_amax,
-    tensor_to_scale,
-    to_fp8_saturated,
-)
+from float8_experimental.float8_utils import tensor_to_amax, to_fp8_saturated
 
 from torch.distributed._tensor import DTensor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ test = [
     "transformers==4.32.0",
     "pandas >= 2.0",
     "tqdm==4.66.2",
-    "fire==0.5.0"
+    "fire==0.5.0",
+    "expecttest",
 ]
 dev = [
     "black==23.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,54 @@ dev = [
 first_party_detection = false
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.10
+target-version = "py310"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E731"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,17 +33,9 @@ dev = [
     "pytest==7.4.0",
     "bumpver",
     "pip-tools",
-    "flake8-pyproject"
+    "ruff==0.3.0"
 ]
-
-
 # ---------- TOOL CONFIGURATIONS ------------
-[tool.flake8]
-ignore = ['E231', 'E241', 'E501', 'C408', 'E261', 'E731', 'G004', 'W503', 'E203']
-per-file-ignores = [
-    '__init__.py:F401',
-]
-
 [tool.usort]
 first_party_detection = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 test = [
     "transformers==4.32.0",
     "pandas >= 2.0",
-    "tqdm==4.66.1",
+    "tqdm==4.66.2",
     "fire==0.5.0"
 ]
 dev = [
@@ -32,13 +32,17 @@ dev = [
     "libcst==1.0.1",
     "pytest==7.4.0",
     "bumpver",
-    "pip-tools"
+    "pip-tools",
+    "flake8-pyproject"
 ]
 
-# Since we have multiple top level folders we specify what we want to be included
-# in the package
-[tool.setuptools]
-packages = ["float8_experimental"]
+
+# ---------- TOOL CONFIGURATIONS ------------
+[tool.flake8]
+ignore = ['E231', 'E241', 'E501', 'C408', 'E261', 'E731', 'G004', 'W503', 'E203']
+per-file-ignores = [
+    '__init__.py:F401',
+]
 
 [tool.usort]
 first_party_detection = false

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -114,7 +114,7 @@ class TestFloat8Linear:
                 ), f"{buffer_name} not filled, current value {buffer_value}"
 
             # verify initialization flags got updated
-            assert m_fp8.is_amax_initialized == True
+            assert m_fp8.is_amax_initialized, "Amax was not properly initialized"
 
     @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -26,7 +26,6 @@ from float8_experimental.float8_tensor import Float8Tensor
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
 
-# Setting to unblock for calling contiguous in backwards
 is_H100 = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0)
 
 
@@ -150,6 +149,7 @@ class TestGraphBreaks(DynamoTestCase):
                 return x_hp
             return x_fp8
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8Tensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
@@ -162,6 +162,7 @@ class TestGraphBreaks(DynamoTestCase):
         self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
         torch.testing.assert_close(y_eager, y_compiled)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_float8_graph_input(self):
         """Test that having Float8Tensor object as a graph input"""
 
@@ -182,6 +183,7 @@ class TestGraphBreaks(DynamoTestCase):
         )
         torch.testing.assert_close(y2_eager, y2_compiled)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_float8_graph_output(self):
         """Test that having Float8Tensor object as a graph output works"""
         cnts = CompileCounterWithBackend("inductor")

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -10,15 +10,12 @@ Test numerics of manually defined float16 TP vs float8 TP of toy models
 import os
 
 import torch
-import torch.nn as nn
 
 from float8_experimental.float8_dynamic_linear import NoopFwToFloat8E5M2Bw
 from float8_experimental.float8_tensor import Float8Tensor
 from float8_experimental.float8_utils import tensor_to_scale
-from torch.distributed import init_process_group
 from torch.distributed._tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.testing._internal.distributed.fake_pg import FakeStore
 from tqdm import tqdm
 
 

--- a/test/test_dtensor.sh
+++ b/test/test_dtensor.sh
@@ -5,7 +5,7 @@ set -e
 
 if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
     echo "Skipping test_dtensor.sh because no CUDA devices are available."
-    return
+    exit
 fi
 
 NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/test_dtensor.py

--- a/test/test_dtensor.sh
+++ b/test/test_dtensor.sh
@@ -3,4 +3,9 @@
 # terminate script on first error
 set -e
 
+if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
+    echo "Skipping test_dtensor.sh because no CUDA devices are available."
+    return
+fi
+
 NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/test_dtensor.py

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -212,7 +212,6 @@ def run(mode: str, is_fp8: bool, compile_fsdp: bool = False, fullgraph: bool = F
         torch.testing.assert_close(y_single_gpu, y_fsdp, atol=atol, rtol=rtol)
         print("output testing single_gpu vs FSDP success")
 
-        sd_in = torch.load(sd_in_fname)
         sd_out_single_gpu = torch.load(sd_out_single_gpu_fname)
         sd_out_fsdp = torch.load(sd_out_fsdp_fname)
         for k, v1 in sd_out_single_gpu.items():
@@ -248,10 +247,10 @@ def run(mode: str, is_fp8: bool, compile_fsdp: bool = False, fullgraph: bool = F
                 pass
             else:
                 try:
-                    if v1.dtype == torch.bfloat16 and emulate == False:
+                    if v1.dtype == torch.bfloat16 and not emulate:
                         atol, rtol = 2e-2, 2e-2
                     else:
-                        if k == "1.fp8_amax_history_x" and emulate == False:
+                        if k == "1.fp8_amax_history_x" and not emulate:
                             atol, rtol = 2e-2, 6e-3
                         else:
                             atol, rtol = None, None

--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -29,6 +29,11 @@ launch() {
     echo "✅ All Tests Passed ✅"
 }
 
+if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
+    echo "Skipping test_fsdp.sh because no CUDA devices are available."
+    return
+fi
+
 # IS_FP8, COMPILE, FULLGRAPH
 for i in False,False,False True,False,False True,True,False
 do

--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -31,7 +31,7 @@ launch() {
 
 if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
     echo "Skipping test_fsdp.sh because no CUDA devices are available."
-    return
+    exit
 fi
 
 # IS_FP8, COMPILE, FULLGRAPH

--- a/test/test_fsdp_compile.sh
+++ b/test/test_fsdp_compile.sh
@@ -4,7 +4,7 @@
 set -e
 if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
     echo "Skipping test_fsdp_compile.sh because no CUDA devices are available."
-    return
+    exit
 fi
 
 # Code to be executed if CUDA devices are available

--- a/test/test_fsdp_compile.sh
+++ b/test/test_fsdp_compile.sh
@@ -2,5 +2,10 @@
 
 # terminate script on first error
 set -e
+if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
+    echo "Skipping test_fsdp_compile.sh because no CUDA devices are available."
+    return
+fi
 
+# Code to be executed if CUDA devices are available
 NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/test_fsdp_compile.py

--- a/test/test_sam.py
+++ b/test/test_sam.py
@@ -25,6 +25,7 @@ torch.manual_seed(0)
 
 class TestFloat8SAMIntegrationTest:
     @pytest.mark.parametrize("data_dtype", [torch.float16, torch.bfloat16])
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
     def test_encoder_fw_bw(self, data_dtype):
         model = SamModel.from_pretrained("facebook/sam-vit-base").to(data_dtype).cuda()
         # print(model)

--- a/test/test_tp.py
+++ b/test/test_tp.py
@@ -149,6 +149,9 @@ def test_ffn_sp(local_rank, world_size):
 
 
 if __name__ == "__main__":
+    if not torch.cuda.is_available():
+        print("CUDA not available, skipping tests")
+        exit(0)
     local_rank, world_size = setup_model_parallel()
     test_column_parallel_linear()
     test_row_parallel_linear()

--- a/test/test_tp.sh
+++ b/test/test_tp.sh
@@ -3,4 +3,9 @@
 # terminate script on first error
 set -e
 
+if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
+    echo "Skipping test_tp.sh because no CUDA devices are available."
+    return
+fi
+
 NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/test_tp.py

--- a/test/test_tp.sh
+++ b/test/test_tp.sh
@@ -5,7 +5,7 @@ set -e
 
 if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
     echo "Skipping test_tp.sh because no CUDA devices are available."
-    return
+    exit
 fi
 
 NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/test_tp.py


### PR DESCRIPTION
# Summary
Some quality of life changes

### Details:
- Use Ruff for linting, majority of file changes were are from this
- Add in pre-commit conifg so that user don't forget 😉
- Add both linting and testing github actions. NOTE: this is very non exhaustive, we don't currently have an gpu runners and even if we did they would need to be h100 or sm89 to significantly cover  the tests we have, but something is better than nothing

#### One auxiliary change 
- While doing this PR I noticed that the c10d ops have been updated to _c10d so registered this ops to float8 tensor class and test/test_dtensor works
