### PR TITLE
Added eager fp8 all-gather for dynamic scaling (subclass)

### DIFF
--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -14,3 +14,8 @@ enable_amax_init = True
 # this doesn't work with autocast + torch.compile + FSDP. Enabling this
 # option is useful for safety, but not strictly necessary.
 enable_pre_and_post_forward = True
+
+# If True, then uses a tensor subclass for the fp8 linear module's weight that
+# implements pre/post-all-gather methods to do fp8 all-gather with FSDP2.
+# Only dynamic scaling is supported for now.
+enable_fsdp_fp8_all_gather = False

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -7,6 +7,7 @@
 A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 """
 
+import logging
 from typing import Any, Optional, Tuple
 
 import torch
@@ -20,7 +21,7 @@ from float8_experimental.float8_tensor import (
 )
 from float8_experimental.float8_utils import tensor_to_scale
 from torch._prims_common import suggest_memory_format
-import logging
+
 log = logging.getLogger(__name__)
 
 

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -154,9 +154,6 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
     def __init__(self, tensor: torch.Tensor, emulate: bool):
         self._tensor = tensor
         self._emulate = emulate
-        # Optional cache for pre-computed fp8 data/scale
-        self._fp8_data: Optional[torch.Tensor] = None
-        self._fp8_scale: Optional[torch.Tensor] = None
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs=None):
@@ -191,8 +188,6 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
         return f"WeightWithDynamicFloat8CastTensor(tensor={self._tensor}, emulate={self._emulate})"
 
     def fsdp_pre_all_gather(self, mesh):
-        if self._fp8_data is not None and self._fp8_scale is not None:
-            return (self._fp8_data,), (self._fp8_scale,)
         float8_tensor = cast_to_float8_e4m3fn(
             self._tensor, self._emulate, reduce_amax=True
         )

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -6,7 +6,12 @@
 """
 A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 """
+
+from typing import Any, Optional, Tuple
+
 import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
@@ -14,6 +19,7 @@ from float8_experimental.float8_tensor import (
     to_fp8_no_autograd,
 )
 from float8_experimental.float8_utils import tensor_to_scale
+from torch._prims_common import suggest_memory_format
 
 
 @torch._dynamo.allow_in_graph
@@ -35,13 +41,23 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
     @staticmethod
     def backward(ctx, gradY):
         if tensor_already_casted_to_fp8(gradY):
-            # check to early return if already casted to float8
             return gradY, None
         gradY_scale = tensor_to_scale(gradY, torch.float8_e5m2)
         fp8_tensor = to_fp8_no_autograd(
             gradY, gradY_scale, torch.float8_e5m2, ctx.emulate
         )
         return fp8_tensor, None
+
+
+def cast_to_float8_e4m3fn(
+    inpt_tensor: torch.Tensor, emulate: bool, reduce_amax: bool = False
+) -> Float8Tensor:
+    if tensor_already_casted_to_fp8(inpt_tensor):
+        return inpt_tensor
+    scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn, reduce_amax)
+    return Float8Tensor.to_float8(
+        inpt_tensor, scale, torch.float8_e4m3fn, emulate=emulate
+    )
 
 
 class Float8DynamicLinear(torch.nn.Linear):
@@ -54,39 +70,38 @@ class Float8DynamicLinear(torch.nn.Linear):
         super().__init__(**super_kwargs)
 
     def forward(self, x):
-        # cast x to float8_e4m3fn if not using activation hooks
         x_fp8 = self.cast_to_float8_e4m3fn(x)
-
-        # cast w to float8_e4m3fn
-        w_fp8 = self.cast_to_float8_e4m3fn(self.weight)
-
+        w_fp8 = (
+            self.weight
+            if isinstance(self.weight, Float8Tensor)  # cast by FSDP
+            else self.cast_to_float8_e4m3fn(self.weight)
+        )
         y = torch.nn.functional.linear(x_fp8, w_fp8, self.bias)
-
-        # Cast gradY to float8_e5m2 during backward if not using activation hooks
         y = self.cast_to_float8_e5m2_bw(y)
-
         return y
 
-    def cast_to_float8_e4m3fn(self, inpt_tensor: torch.Tensor) -> Float8Tensor:
-        if tensor_already_casted_to_fp8(inpt_tensor):
-            # check to early return if already casted to float8
-            return inpt_tensor
-        scale = tensor_to_scale(inpt_tensor, torch.float8_e4m3fn)
-        return Float8Tensor.to_float8(
-            inpt_tensor, scale, torch.float8_e4m3fn, emulate=self.emulate
-        )
+    def cast_to_float8_e4m3fn(
+        self, inpt_tensor: torch.Tensor, reduce_amax: bool = False
+    ) -> Float8Tensor:
+        return cast_to_float8_e4m3fn(inpt_tensor, self.emulate, reduce_amax)
 
     def cast_to_float8_e5m2_bw(self, gradY: torch.Tensor) -> torch.Tensor:
         return NoopFwToFloat8E5M2Bw.apply(gradY, self.emulate)
 
     @classmethod
-    def from_float(cls, mod, emulate: bool = False) -> "Float8DynamicLinear":
+    def from_float(
+        cls,
+        mod,
+        emulate: bool = False,
+        use_fp8_all_gather: bool = False,
+    ) -> "Float8DynamicLinear":
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
 
         Args:
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
+            use_fp8_all_gather (bool): whether to use fp8 all-gather for FSDP
         """
         with torch.device("meta"):
             super_kwargs = {
@@ -95,7 +110,103 @@ class Float8DynamicLinear(torch.nn.Linear):
                 "bias": False,
             }
             new_mod = cls(**super_kwargs)
-        new_mod.weight = mod.weight
+        new_mod.weight = (
+            nn.Parameter(Float8DynamicLinearWeightTensor(mod.weight, emulate))
+            if use_fp8_all_gather
+            else mod.weight
+        )
         new_mod.bias = mod.bias
         new_mod.emulate = emulate
         return new_mod
+
+
+# FSDP pads its local tensor on dim-0. The subclass should be preserved such
+# that the padded local tensor (and any transformations like copying to GPU)
+# is of the subclass as well.
+_ops_to_preserve_subclass = {
+    torch.ops.aten.new_zeros.default,
+    torch.ops.aten.slice.Tensor,
+    torch.ops.aten.copy_.default,
+    torch.ops.aten.view.default,
+    torch.ops.aten.as_strided.default,
+    torch.ops.aten._to_copy.default,
+    torch.ops.aten._pin_memory.default,
+}
+
+
+class Float8DynamicLinearWeightTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, tensor: torch.Tensor, emulate: bool):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            tensor.size(),
+            strides=tensor.stride(),
+            storage_offset=tensor.storage_offset(),
+            memory_format=suggest_memory_format(tensor),
+            dtype=tensor.dtype,
+            layout=tensor.layout,
+            device=tensor.device,
+            pin_memory=tensor.is_pinned(),
+            requires_grad=tensor.requires_grad,
+        )
+
+    def __init__(self, tensor: torch.Tensor, emulate: bool):
+        self._tensor = tensor
+        self._emulate = emulate
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs=None):
+        if func == torch.ops.aten.detach.default:
+            return args[0]
+        emulate = False
+
+        def unwrap(t):
+            nonlocal emulate
+            emulate |= t._emulate
+            return t._tensor
+
+        args, kwargs = pytree.tree_map_only(
+            Float8DynamicLinearWeightTensor, unwrap, (args, kwargs or {})
+        )
+        out = func(*args, **kwargs)
+        if func not in _ops_to_preserve_subclass:
+            return out
+        return pytree.tree_map_only(
+            torch.Tensor, lambda x: Float8DynamicLinearWeightTensor(x, emulate), out
+        )
+
+    def __tensor_flatten__(self):
+        return ["_tensor"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):
+        return Float8DynamicLinearWeightTensor(inner_tensors["_tensor"])
+
+    def __repr__(self):
+        return f"Float8DynamicLinearWeightTensor(tensor={self._tensor}, emulate={self._emulate})"
+
+    def fsdp_pre_all_gather(self):
+        float8_tensor = cast_to_float8_e4m3fn(
+            self._tensor, self._emulate, reduce_amax=True
+        )
+        return (float8_tensor._data,), (float8_tensor._scale,)
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs: Tuple[torch.Tensor, ...],
+        metadata: Any,
+        param_dtype: torch.dtype,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ):
+        (data,) = all_gather_outputs
+        (scale,) = metadata
+        if out is not None:
+            assert isinstance(out, Float8Tensor), f"{type(out)}"
+            assert (
+                data.untyped_storage().data_ptr()
+                == out._data.untyped_storage().data_ptr()
+            ), f"Expects out's data to be the all-gather output"
+            out._scale = scale
+            return
+        return Float8Tensor(data, scale, param_dtype, self._emulate), (data,)

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -176,11 +176,12 @@ class Float8DynamicLinearWeightTensor(torch.Tensor):
         )
 
     def __tensor_flatten__(self):
-        return ["_tensor"], None
+        return ["_tensor"], self._emulate
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):
-        return Float8DynamicLinearWeightTensor(inner_tensors["_tensor"])
+        emulate = flatten_spec
+        return Float8DynamicLinearWeightTensor(inner_tensors["_tensor"], emulate)
 
     def __repr__(self):
         return f"Float8DynamicLinearWeightTensor(tensor={self._tensor}, emulate={self._emulate})"

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -10,6 +10,8 @@ A wrapper around a `torch.nn.Linear` module which does fp8 compute.
 import logging
 from typing import Any, Optional, Tuple
 
+import float8_experimental.config as config
+
 import torch
 import torch.nn as nn
 import torch.utils._pytree as pytree
@@ -96,7 +98,6 @@ class Float8DynamicLinear(torch.nn.Linear):
         cls,
         mod,
         emulate: bool = False,
-        use_fsdp_fp8_all_gather: bool = False,
     ) -> "Float8DynamicLinear":
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
@@ -104,7 +105,6 @@ class Float8DynamicLinear(torch.nn.Linear):
         Args:
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
-            use_fsdp_fp8_all_gather (bool): whether to use fp8 all-gather for FSDP
         """
         with torch.device("meta"):
             super_kwargs = {
@@ -115,7 +115,7 @@ class Float8DynamicLinear(torch.nn.Linear):
             new_mod = cls(**super_kwargs)
         new_mod.weight = (
             nn.Parameter(Float8DynamicLinearWeightTensor(mod.weight, emulate))
-            if use_fsdp_fp8_all_gather
+            if config.enable_fsdp_fp8_all_gather
             else mod.weight
         )
         new_mod.bias = mod.bias

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -48,7 +48,7 @@ def _maybe_initialize_amaxes_scales_for_float8_cast(
     with torch.no_grad():
         # Note: we need to enable distributed reduction here in order
         # to match numerics between single GPU and multi GPU code
-        new_amax = tensor_to_amax(x, distributed_reduction=True)
+        new_amax = tensor_to_amax(x, reduce_amax=True)
         cur_amax.fill_(new_amax)
         amax_history[0] = new_amax
         new_scale = amax_history_to_scale(

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -109,7 +109,6 @@ def swap_linear_with_float8_linear(
     skip_fqn_list: Optional[List[str]] = None,
     emulate: bool = False,
     linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
-    use_fsdp_fp8_all_gather: bool = False,
 ) -> nn.Module:
     """
     Replaces all instances of ``torch.nn.Linear`` in ``module`` with instances
@@ -123,16 +122,8 @@ def swap_linear_with_float8_linear(
         emulate (bool): Whether to emulate the fp8 matmul logic in fp32.
         linear_layer_filter (Optional[Callable[[nn.Linear], bool]]): If specified, only the linear layers
             that pass the filter function will be swapped.
-        use_fsdp_fp8_all_gather (bool): Whether to use fp8 all-gather for FSDP.
     """
-    if use_fsdp_fp8_all_gather and module_cls is not Float8DynamicLinear:
-        raise NotImplementedError(
-            f"use_fsdp_fp8_all_gather=True can only be used with Float8DynamicLinear, not {module_cls}"
-        )
     float8_kwargs = {"emulate": emulate}
-    if use_fsdp_fp8_all_gather:
-        # Only a kwarg for dynamic linear
-        float8_kwargs["use_fsdp_fp8_all_gather"] = True
     module_names_to_skip = set(skip_fqn_list or [])
     if isinstance(module, nn.Linear) and (
         linear_layer_filter is None or linear_layer_filter(module)

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -12,7 +12,10 @@ from typing import Callable, List, Optional, Type
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from float8_experimental.float8_dynamic_linear import Float8DynamicLinear, Float8DynamicLinearWeightTensor
+from float8_experimental.float8_dynamic_linear import (
+    Float8DynamicLinear,
+    Float8DynamicLinearWeightTensor,
+)
 from float8_experimental.float8_linear import Float8Linear
 
 from float8_experimental.float8_utils import (
@@ -354,9 +357,7 @@ def precompute_float8_weights(module: nn.Module) -> None:
         and isinstance(m.weight, DTensor)
         and isinstance(m.weight._local_tensor, Float8DynamicLinearWeightTensor)
     ]
-    weights: List[DTensor] = [
-        float8_linear.weight for float8_linear in float8_linears
-    ]
+    weights: List[DTensor] = [float8_linear.weight for float8_linear in float8_linears]
 
     def compute_weights_and_scales(weights: List[DTensor]):
         abs_weights = torch._foreach_abs(weights)
@@ -377,7 +378,9 @@ def precompute_float8_weights(module: nn.Module) -> None:
         # datas, scales = torch.compile(compute_weights_and_scales, mode="reduce-overhead")(weights)
         for data, scale, float8_linear in zip(datas, scales, float8_linears):
             float8_linear.weight._local_tensor._fp8_data = data._local_tensor
-            float8_linear.weight._local_tensor._fp8_scale = scale._local_tensor.squeeze()
+            float8_linear.weight._local_tensor._fp8_scale = (
+                scale._local_tensor.squeeze()
+            )
     else:
         warnings.warn(
             "Calling precompute_float8_weights without any weights using FSDP fp8 all-gather!"

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -123,7 +123,6 @@ def swap_linear_with_float8_linear(
         linear_layer_filter (Optional[Callable[[nn.Linear], bool]]): If specified, only the linear layers
             that pass the filter function will be swapped.
     """
-    float8_kwargs = {"emulate": emulate}
     module_names_to_skip = set(skip_fqn_list or [])
     if isinstance(module, nn.Linear) and (
         linear_layer_filter is None or linear_layer_filter(module)
@@ -132,7 +131,7 @@ def swap_linear_with_float8_linear(
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        return module_cls.from_float(module, **float8_kwargs)
+        return module_cls.from_float(module, emulate=emulate)
 
     # Mark all modules to skip as visited
     root_module = module
@@ -156,7 +155,7 @@ def swap_linear_with_float8_linear(
             assert (
                 parent_module is not None
             ), f"Linear root module should return early: {module}"
-            float8linear_module = module_cls.from_float(module, **float8_kwargs)
+            float8linear_module = module_cls.from_float(module, emuluate=emulate)
             setattr(parent_module, module_name, float8linear_module)
 
     post_order_traversal(root_module, "", None)

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -146,7 +146,7 @@ def swap_linear_with_float8_linear(
             assert (
                 parent_module is not None
             ), f"Linear root module should return early: {module}"
-            float8linear_module = module_cls.from_float(module, emuluate=emulate)
+            float8linear_module = module_cls.from_float(module, emulate=emulate)
             setattr(parent_module, module_name, float8linear_module)
 
     post_order_traversal(root_module, "", None)

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from float8_experimental.float8_dynamic_linear import (
     Float8DynamicLinear,
-    Float8DynamicLinearWeightTensor,
+    WeightWithDynamicFloat8CastTensor,
 )
 from float8_experimental.float8_linear import Float8Linear
 
@@ -346,7 +346,7 @@ def precompute_float8_weights(module: nn.Module) -> None:
         for m in module.modules()
         if isinstance(m, Float8DynamicLinear)
         and isinstance(m.weight, DTensor)
-        and isinstance(m.weight._local_tensor, Float8DynamicLinearWeightTensor)
+        and isinstance(m.weight._local_tensor, WeightWithDynamicFloat8CastTensor)
     ]
     weights: List[DTensor] = [float8_linear.weight for float8_linear in float8_linears]
 

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -5,25 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 import copy
 import logging
-import warnings
 from enum import auto, Enum
 from typing import Callable, List, Optional, Type
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from float8_experimental.float8_dynamic_linear import (
-    Float8DynamicLinear,
-    WeightWithDynamicFloat8CastTensor,
-)
+from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear
 
-from float8_experimental.float8_utils import (
-    amax_history_to_scale_stack,
-    E4M3_MAX_POS,
-    EPS,
-    to_fp8_saturated,
-)
+from float8_experimental.float8_utils import amax_history_to_scale_stack
 from torch.distributed._functional_collectives import all_reduce, AsyncCollectiveTensor
 
 log = logging.getLogger(__name__)
@@ -331,47 +322,3 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
     for child in fp8_layers:
         # Set a flag to signal amaxes/scales are ready
         child.amax_and_scale_synced = True
-
-
-def precompute_float8_weights(module: nn.Module) -> None:
-    from torch.distributed._tensor import DTensor
-
-    if any(isinstance(m, Float8Linear) for m in module.modules()):
-        raise NotImplementedError(
-            f"Only supports Float8DynamicLinear, not Float8Linear"
-        )
-    float8_linears: List[Float8DynamicLinear] = [
-        m
-        for m in module.modules()
-        if isinstance(m, Float8DynamicLinear)
-        and isinstance(m.weight, DTensor)
-        and isinstance(m.weight._local_tensor, WeightWithDynamicFloat8CastTensor)
-    ]
-    weights: List[DTensor] = [float8_linear.weight for float8_linear in float8_linears]
-
-    def compute_weights_and_scales(weights: List[DTensor]):
-        abs_weights = torch._foreach_abs(weights)
-        # abs_weights = [torch.abs(w) for w in weights]
-        amax_tensor = torch.vstack([torch.max(a) for a in abs_weights])
-        amax_tensor = torch.clamp(amax_tensor, EPS)
-        scales_tensor = E4M3_MAX_POS / amax_tensor
-        scales = torch.split(scales_tensor, 1)
-        weights_scaled = torch._foreach_mul(weights, scales)
-        datas = [to_fp8_saturated(w, torch.float8_e4m3fn) for w in weights_scaled]
-        # torch._foreach_clamp_min_(weights_scaled, -1 * E4M3_MAX_POS)
-        # torch._foreach_clamp_max_(weights_scaled, E4M3_MAX_POS)
-        # datas = [w.to(torch.float8_e4m3fn) for w in weights_scaled]
-        return datas, scales
-
-    if weights:
-        datas, scales = compute_weights_and_scales(weights)
-        # datas, scales = torch.compile(compute_weights_and_scales, mode="reduce-overhead")(weights)
-        for data, scale, float8_linear in zip(datas, scales, float8_linears):
-            float8_linear.weight._local_tensor._fp8_data = data._local_tensor
-            float8_linear.weight._local_tensor._fp8_scale = (
-                scale._local_tensor.squeeze()
-            )
-    else:
-        warnings.warn(
-            "Calling precompute_float8_weights without any weights using FSDP fp8 all-gather!"
-        )

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -70,21 +70,23 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x, distributed_reduction=False):
+def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will
     # happen elsewhere.
-    if distributed_reduction and dist.is_initialized():
+    if reduce_amax and dist.is_initialized():
         dist.all_reduce(amax, op=dist.ReduceOp.MAX)
 
     return amax
 
 
 @torch.no_grad()
-def tensor_to_scale(x, float8_dtype):
-    amax = tensor_to_amax(x)
+def tensor_to_scale(
+    x: torch.Tensor, float8_dtype: torch.dtype, reduce_amax: bool = False
+) -> torch.Tensor:
+    amax = tensor_to_amax(x, reduce_amax=reduce_amax)
     return amax_to_scale(amax, float8_dtype, x.dtype)
 
 

--- a/test/test_everything.sh
+++ b/test/test_everything.sh
@@ -9,5 +9,6 @@ pytest test/test_compile.py
 ./test/test_fsdp.sh
 ./test/test_fsdp_compile.sh
 ./test/test_dtensor.sh
+pytest test/test_fsdp2/test_fsdp2_eager.py
 
 echo "all tests successful"

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -1,4 +1,7 @@
+import contextlib
 from typing import List, Type
+
+import float8_experimental.config as config
 
 import torch
 import torch.distributed as dist
@@ -67,3 +70,15 @@ def check_parity_bf16_mp(
             ):
                 param_bf16.detach().copy_(param_fp32)
         test_cls.assertEqual(losses[0], losses[1])
+
+
+@contextlib.contextmanager
+def set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather: bool):
+    prev = config.enable_fsdp_fp8_all_gather
+    dist.barrier()
+    config.enable_fsdp_fp8_all_gather = enable_fsdp_fp8_all_gather
+    try:
+        yield
+    finally:
+        dist.barrier()
+        config.enable_fsdp_fp8_all_gather = prev

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -1,0 +1,69 @@
+from typing import List, Type
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear_utils import sync_float8_amax_and_scale_history
+
+
+def check_parity_no_mp(
+    test_cls,
+    ref_model: nn.Module,
+    ref_optim: torch.optim.Optimizer,
+    fsdp_model: nn.Module,
+    fsdp_optim: torch.optim.Optimizer,
+    local_inp: torch.Tensor,
+    module_cls: Type,
+):
+    for iter_idx in range(10):
+        losses: List[torch.Tensor] = []
+        for model, optim in ((ref_model, ref_optim), (fsdp_model, fsdp_optim)):
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            losses.append(model(local_inp).sum())
+            losses[-1].backward()
+            if model is ref_model:
+                for param in model.parameters():
+                    dist.all_reduce(param.grad)
+                    param.grad.div_(dist.get_world_size())
+            if module_cls is Float8Linear:
+                sync_float8_amax_and_scale_history(model)
+            optim.step()
+        test_cls.assertEqual(losses[0], losses[1])
+
+
+def check_parity_bf16_mp(
+    test_cls,
+    ref_model: nn.Module,
+    ref_model_bf16: nn.Module,
+    ref_optim: torch.optim.Optimizer,
+    fsdp_model: nn.Module,
+    fsdp_optim: torch.optim.Optimizer,
+    local_inp: torch.Tensor,
+    module_cls: Type,
+):
+    for iter_idx in range(10):
+        losses: List[torch.Tensor] = []
+        for model, optim in (
+            (ref_model_bf16, ref_optim),
+            (fsdp_model, fsdp_optim),
+        ):
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            losses.append(model(local_inp).sum())
+            losses[-1].backward()
+            if model is ref_model_bf16:
+                for param_bf16, param_fp32 in zip(
+                    ref_model_bf16.parameters(), ref_model.parameters()
+                ):
+                    dist.all_reduce(param_bf16.grad)
+                    param_bf16.grad.div_(dist.get_world_size())
+                    param_fp32.grad = param_bf16.grad.float()
+                    param_bf16.grad = None
+            if module_cls is Float8Linear:
+                sync_float8_amax_and_scale_history(model)
+            optim.step()
+            for param_fp32, param_bf16 in zip(
+                ref_model.parameters(), ref_model_bf16.parameters()
+            ):
+                param_bf16.detach().copy_(param_fp32)
+        test_cls.assertEqual(losses[0], losses[1])

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -1,0 +1,449 @@
+import copy
+import threading
+import unittest
+from typing import Any, List
+
+import torch
+import torch._dynamo.testing
+import torch.distributed as dist
+import torch.nn as nn
+from float8_experimental.float8_dynamic_linear import (
+    Float8DynamicLinear,
+    Float8DynamicLinearWeightTensor,
+)
+from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
+from test_fsdp2_common import check_parity_bf16_mp, check_parity_no_mp
+from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
+from torch.distributed._tensor import DTensor
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+    FSDPTestMultiThread,
+    MLP,
+    patch_all_gather,
+)
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+    TransformerBlock,
+)
+
+
+class TestFloat8Common:
+    def broadcast_module(self, module: nn.Module) -> None:
+        # Broadcast for multi-threaded process group tests since seed is per
+        # process, not per thread
+        for param in module.parameters():
+            dist.broadcast(param, src=0)
+
+    def init_single_module(self) -> nn.Module:
+        torch.manual_seed(42)
+        module = nn.Linear(16, 16, device="cuda")
+        self.broadcast_module(module)
+        return module
+
+    def init_multi_module(self) -> nn.Module:
+        torch.manual_seed(42)
+        module = nn.Sequential(*[MLP(16, device="cuda") for _ in range(3)])
+        self.broadcast_module(module)
+        return module
+
+    def init_transformer(self, weight_tying: bool) -> nn.Module:
+        torch.manual_seed(42)
+        args = ModelArgs(
+            n_layers=3, dim=768, n_heads=12, dropout_p=0.0, weight_tying=weight_tying
+        )
+        module = Transformer(args).cuda()
+        self.broadcast_module(module)
+        return module
+
+    def get_local_inp(self, dtype: torch.dtype = torch.float32):
+        torch.manual_seed(42)
+        global_inp = torch.randn((16 * self.world_size, 16), device="cuda", dtype=dtype)
+        dist.broadcast(global_inp, src=0)
+        return global_inp.view(self.world_size, -1)[self.rank].view(16, 16)
+
+    def swap_linear_with_dynamic(self, module: nn.Module, **kwargs: Any) -> nn.Module:
+        # Always use activation hooks since we need it to compose with DTensor
+        # tensor parallelism
+        return swap_linear_with_float8_linear(module, Float8DynamicLinear, **kwargs)
+
+
+class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
+    @property
+    def world_size(self) -> int:
+        return min(torch.cuda.device_count(), 2)
+
+    @skip_if_lt_x_gpu(2)
+    def test_transformer_parity_dynamic(self):
+        for use_fp8_all_gather in [False, True]:
+            self._test_transformer_parity_dynamic(use_fp8_all_gather)
+
+    def _test_transformer_parity_dynamic(self, use_fp8_all_gather: bool):
+        # NOTE: Weight-tying does not compose with fp8 all-gather because the
+        # embedding weight and output linear weight are tied but only the
+        # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
+        # fp8 for that tied weight, incorrectly using fp8 for the embedding.
+        weight_tying = not use_fp8_all_gather
+        module = self.init_transformer(weight_tying=weight_tying)
+        ref_module = copy.deepcopy(module)
+        ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
+        module = self.swap_linear_with_dynamic(
+            module, use_fp8_all_gather=use_fp8_all_gather
+        )
+        for submodule in module.modules():
+            if isinstance(submodule, TransformerBlock):
+                fully_shard(submodule)
+        fully_shard(module)
+        ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+        optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+        local_inp = torch.randint(
+            0, ref_module.tok_embeddings.weight.size(0), (16, 16), device="cuda"
+        )
+        check_parity_no_mp(
+            self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_transformer_memory(self):
+        """Tests peak active memory in the forward and backward passes."""
+        # for use_fp8_all_gather in [False, True]:
+        for use_fp8_all_gather in [True]:
+            self._test_transformer_memory(use_fp8_all_gather)
+
+    def _test_transformer_memory(self, use_fp8_all_gather: bool):
+        torch.manual_seed(42)
+        # Pre-run a linear forward (gemm and bias) and backward (gemm) to
+        # allocate the cuBLAS workspaces before measuring the memory usage
+        # since the workspace size can differ between hardwares
+        lin = torch.nn.Linear(768, 768, device="cuda")
+        inp = torch.randn(1, 768, device="cuda")
+        lin(inp).sum().backward()
+        torch.cuda.empty_cache()
+        base_mem_mb = self._get_peak_active_memory_mb()
+
+        vocab_size = 32
+        model_args = ModelArgs(
+            vocab_size=vocab_size,
+            n_layers=3,
+            dim=768,
+            n_heads=12,
+            weight_tying=False,
+        )
+        model = Transformer(model_args)
+        # Emulate the fp8 matmul to bypass the scaled matmul op's divisibility
+        # requirement to use a smaller activation size
+        model = self.swap_linear_with_dynamic(
+            model, use_fp8_all_gather=use_fp8_all_gather, emulate=True
+        )
+        model_unsharded_numel = sum(p.numel() for p in model.parameters())
+        model_sharded_numel = (model_unsharded_numel + 1) // 2
+        block_lin_weight_numel = 0
+        block_other_numel = 0
+        for module in model.layers[0].modules():
+            for param in module.parameters(recurse=False):
+                if isinstance(module, nn.Linear):
+                    block_lin_weight_numel += param.numel()
+                else:
+                    block_other_numel += param.numel()
+        non_block_numel = round(
+            sum(p.numel() for p in model.tok_embeddings.parameters())
+            + sum(p.numel() for p in model.pos_embeddings.parameters())
+            + sum(p.numel() for p in model.norm.parameters())
+            + sum(p.numel() for p in model.output.parameters())
+        )
+        for module in model.modules():
+            if isinstance(module, TransformerBlock):
+                fully_shard(module)
+        fully_shard(model)
+
+        # Init: Each module is moved to GPU before sharding parameters
+        peak_mem_mb = self._get_peak_active_memory_mb()
+        curr_mem_mb = self._get_curr_active_memory_mb()
+        init_mem_mb = (
+            (model_sharded_numel + block_lin_weight_numel + block_other_numel) * 4 / 1e6
+        )
+        # Allow for some buffer for the peak memory since original parameters
+        # are not freed until a `fully_shard` call returns
+        buffer_mb = 4
+        self.assertLessEqual(peak_mem_mb - base_mem_mb, init_mem_mb + buffer_mb)
+        self.assertLessEqual(curr_mem_mb - base_mem_mb, init_mem_mb)
+
+        # Use a small input to minimize activation memory usage
+        inp = torch.randint(0, vocab_size, (1, 4), device="cuda")
+
+        # Forward:
+        loss = model(inp)
+        mem_mb = self._get_peak_active_memory_mb()
+        # Allow for some buffer for fragmentation/activations (where this
+        # number is kept much smaller than the actual memory usage, which is on
+        # the order of 100-200+ MB)
+        buffer_mb = 16
+        if use_fp8_all_gather:
+            # Non-block parameters (fp32), 3x block non-linear-weight
+            # parameters (fp32) and block linear-weight parameters (fp8)
+            # (current all-gather, copy-out, and next all-gather), and other
+            expected_mem_mb = (
+                (non_block_numel * 4)
+                + 3 * (block_lin_weight_numel + block_other_numel * 4)
+            ) / 1e6 + buffer_mb
+        else:
+            # Non-block parameters (fp32), 3x block parameters (fp32)
+            # (current all-gather, copy-out, and next all-gather), Nx block
+            # linear-weight parameters (fp8) for N blocks (saved by autograd),
+            # and other
+            expected_mem_mb = (
+                (non_block_numel + 3 * (block_lin_weight_numel + block_other_numel)) * 4
+                + model_args.n_layers * block_lin_weight_numel
+            ) / 1e6 + buffer_mb
+        # Sharded parameters
+        expected_mem_mb += model_sharded_numel * 4 / 1e6
+        self.assertLessEqual(mem_mb, expected_mem_mb + base_mem_mb)
+
+        # Backward:
+        loss.sum().backward()
+        mem_mb = self._get_peak_active_memory_mb()
+        if use_fp8_all_gather:
+            # Non-block parameters (fp32), 2x block non-linear weight
+            # parameters (fp32) and block linear-weight parameters (fp8)
+            # (current copy-out and next all-gather), 1x block gradients (fp32)
+            expected_mem_mb = (
+                (non_block_numel * 4)
+                + 2 * (block_lin_weight_numel + block_other_numel * 4)
+                + 1 * (block_lin_weight_numel + block_other_numel) * 4
+            ) / 1e6 + buffer_mb
+        else:
+            # Non-block parameters (fp32), 3x block parameters (fp32) (current
+            # copy-out, next all-gather, current gradients)
+            expected_mem_mb = (
+                non_block_numel + 3 * (block_lin_weight_numel + block_other_numel) * 4
+            ) * 4 / 1e6 + buffer_mb
+        # 2x sharded parameters/gradients
+        expected_mem_mb += 2 * model_sharded_numel * 4 / 1e6
+        self.assertLessEqual(mem_mb, expected_mem_mb + base_mem_mb)
+
+    def _get_peak_active_memory_mb(self) -> int:
+        mem_stats = torch.cuda.memory_stats()
+        return round(mem_stats["active_bytes.all.peak"] / 1e6)
+
+    def _get_curr_active_memory_mb(self) -> int:
+        mem_stats = torch.cuda.memory_stats()
+        return round(mem_stats["active_bytes.all.current"] / 1e6)
+
+
+class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_weight_subclass_dynamic(self):
+        tensor_cls = Float8DynamicLinearWeightTensor
+        # Check for a single FSDP paramter group
+        module_fp32 = self.init_single_module()
+        module = swap_linear_with_float8_linear(
+            module_fp32,
+            Float8DynamicLinear,
+            emulate=True,
+            use_fp8_all_gather=True,
+        )
+        self.assertIsInstance(module.weight, tensor_cls)
+        fully_shard(module)
+        for param_name, param in module.named_parameters():
+            self.assertIsInstance(param, DTensor)
+            if "weight" in param_name:
+                self.assertIsInstance(param.to_local(), tensor_cls)
+
+        # Check for multiple FSDP paramter groups
+        module = self.init_multi_module()
+        module = swap_linear_with_float8_linear(
+            module,
+            Float8DynamicLinear,
+            emulate=True,
+            use_fp8_all_gather=True,
+        )
+        for param_name, param in module.named_parameters():
+            if "weight" in param_name:
+                self.assertIsInstance(param, tensor_cls)
+        for mlp in module:
+            fully_shard(mlp)
+        fully_shard(module)
+        for param_name, param in module.named_parameters():
+            self.assertIsInstance(param, DTensor)
+            if "weight" in param_name:
+                self.assertIsInstance(param.to_local(), tensor_cls)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp8_fp32_all_gather_dynamic_comm_size(self):
+        """
+        Tests that fp8 all-gather with dynamic scaling communicates the
+        expected number of bytes.
+        """
+        orig_all_gather = dist.all_gather_into_tensor
+        all_gather_sizes: List[int] = []
+        lock = threading.Lock()
+
+        def all_gather(*args: Any, **kwargs: Any):
+            nonlocal all_gather_sizes
+            if len(args) > 0:
+                output = args[0]
+            elif "output_tensor" in kwargs:
+                output = kwargs["output_tensor"]
+            else:
+                raise AssertionError(
+                    f"Cannot get all-gather output from\nargs: {args}\nkwargs: {kwargs}"
+                )
+            with lock:
+                all_gather_sizes.append(output.numel() * output.itemsize)
+            return orig_all_gather(*args, **kwargs)
+
+        def get_expected_all_gather_size(module: nn.Module):
+            size = 0
+            for param_name, param in module.named_parameters():
+                bytes_per_numel = 1 if "weight" in param_name else param.itemsize
+                size += param.numel() * bytes_per_numel
+            return size
+
+        # - Check for a single FSDP parameter group
+        module_fp32 = self.init_single_module()
+        ref_module = copy.deepcopy(module_fp32)
+        module = self.swap_linear_with_dynamic(module_fp32, use_fp8_all_gather=True)
+        fully_shard(module)
+        local_inp = self.get_local_inp()
+        expected_all_gather_size = get_expected_all_gather_size(ref_module)
+        with patch_all_gather(all_gather):
+            out = module(local_inp)
+        # For MPTG, one rank runs all all-gathers, each of the same size
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size)
+            self.assertEqual(
+                all_gather_sizes, [expected_all_gather_size] * self.world_size
+            )
+        all_gather_sizes.clear()
+        # Force-reshard the module to check the backward all-gather
+        module.reshard()
+        with patch_all_gather(all_gather):
+            out.sum().backward()
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size)
+            self.assertEqual(
+                all_gather_sizes, [expected_all_gather_size] * self.world_size
+            )
+        all_gather_sizes.clear()
+
+        # - Check for multiple FSDP parameter groups
+        module = self.init_multi_module()
+        ref_module = copy.deepcopy(module)
+        module = self.swap_linear_with_dynamic(module, use_fp8_all_gather=True)
+        for submodule in module:
+            fully_shard(submodule)
+        fully_shard(module)
+        expected_all_gather_sizes = (
+            get_expected_all_gather_size(submodule) for submodule in module
+        )
+        with patch_all_gather(all_gather):
+            out = module(local_inp)
+        if all_gather_sizes:
+            self.assertEqual(len(all_gather_sizes), self.world_size * len(module))
+            self.assertEqual(
+                all_gather_sizes,
+                [s for s in expected_all_gather_sizes for _ in range(self.world_size)],
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp32_fp8_single_module_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with fp8 computation with a
+        single module/FSDP communication group.
+        """
+        for use_fp8_all_gather in [False, True]:
+            module_fp32 = self.init_single_module()
+            ref_module = self.swap_linear_with_dynamic(copy.deepcopy(module_fp32))
+            ref_module = ref_module.cuda()
+            module = self.swap_linear_with_dynamic(
+                module_fp32, use_fp8_all_gather=use_fp8_all_gather
+            )
+            fully_shard(module)
+            ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+            optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+            local_inp = self.get_local_inp()
+            check_parity_no_mp(
+                self,
+                ref_module,
+                ref_optim,
+                module,
+                optim,
+                local_inp,
+                Float8DynamicLinear,
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fp32_fp8_multi_module_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with fp8 computation with
+        multiple modules/FSDP communication groups.
+        """
+        for use_fp8_all_gather in [False, True]:
+            module = self.init_multi_module()
+            ref_module = copy.deepcopy(module)
+            ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
+            module = self.swap_linear_with_dynamic(
+                module, use_fp8_all_gather=use_fp8_all_gather
+            )
+            for submodule in module:
+                fully_shard(submodule)
+            fully_shard(module)
+            ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
+            optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
+            local_inp = self.get_local_inp()
+            check_parity_no_mp(
+                self,
+                ref_module,
+                ref_optim,
+                module,
+                optim,
+                local_inp,
+                Float8DynamicLinear,
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_bf16_mp_fp8_dynamic_multi_parity(self):
+        """
+        Tests numeric parity for fp32 parameters with FSDP's bf16 mixed
+        precision and fp8 computation with multiple modules/FSDP communication
+        groups. Parameters are all-gathered in bf16 before being cast to fp8.
+        """
+        # NOTE: We cannot test easily with fp8 all-gather because then the scale
+        # is computed using the fp32 sharded parameters, not the bf16 unsharded
+        # parameters, changing the numerics.
+        module = self.init_multi_module()
+        ref_module_bf16 = copy.deepcopy(module).to(torch.bfloat16)
+        ref_module_bf16 = swap_linear_with_float8_linear(
+            ref_module_bf16,
+            Float8DynamicLinear,
+            emulate=True,
+        )
+        ref_module_fp32 = copy.deepcopy(module).cuda()
+        module = swap_linear_with_float8_linear(
+            module, Float8DynamicLinear, emulate=True
+        )
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
+        for mlp in module:
+            fully_shard(mlp, mp_policy=mp_policy)
+        fully_shard(module, mp_policy=mp_policy)
+        check_parity_bf16_mp(
+            self,
+            ref_module_fp32,
+            ref_module_bf16,
+            torch.optim.Adam(ref_module_fp32.parameters(), lr=1e-2),
+            module,
+            torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True),
+            self.get_local_inp(torch.bfloat16),
+            Float8DynamicLinear,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -9,7 +9,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from float8_experimental.float8_dynamic_linear import (
     Float8DynamicLinear,
-    Float8DynamicLinearWeightTensor,
+    WeightWithDynamicFloat8CastTensor,
 )
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from test_fsdp2_common import (
@@ -239,7 +239,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
     def test_weight_subclass_dynamic(self):
-        tensor_cls = Float8DynamicLinearWeightTensor
+        tensor_cls = WeightWithDynamicFloat8CastTensor
         # Check for a single FSDP paramter group
         module_fp32 = self.init_single_module()
         with set_enable_fsdp_fp8_all_gather(True):

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -309,7 +309,9 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         # - Check for a single FSDP parameter group
         module_fp32 = self.init_single_module()
         ref_module = copy.deepcopy(module_fp32)
-        module = self.swap_linear_with_dynamic(module_fp32, use_fsdp_fp8_all_gather=True)
+        module = self.swap_linear_with_dynamic(
+            module_fp32, use_fsdp_fp8_all_gather=True
+        )
         fully_shard(module)
         local_inp = self.get_local_inp()
         expected_all_gather_size = get_expected_all_gather_size(ref_module)

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -12,7 +12,11 @@ from float8_experimental.float8_dynamic_linear import (
     Float8DynamicLinearWeightTensor,
 )
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
-from test_fsdp2_common import check_parity_bf16_mp, check_parity_no_mp
+from test_fsdp2_common import (
+    check_parity_bf16_mp,
+    check_parity_no_mp,
+    set_enable_fsdp_fp8_all_gather,
+)
 from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed._tensor import DTensor
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -66,8 +70,6 @@ class TestFloat8Common:
         return global_inp.view(self.world_size, -1)[self.rank].view(16, 16)
 
     def swap_linear_with_dynamic(self, module: nn.Module, **kwargs: Any) -> nn.Module:
-        # Always use activation hooks since we need it to compose with DTensor
-        # tensor parallelism
         return swap_linear_with_float8_linear(module, Float8DynamicLinear, **kwargs)
 
 
@@ -78,21 +80,20 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
 
     @skip_if_lt_x_gpu(2)
     def test_transformer_parity_dynamic(self):
-        for use_fsdp_fp8_all_gather in [False, True]:
-            self._test_transformer_parity_dynamic(use_fsdp_fp8_all_gather)
+        for enable_fsdp_fp8_all_gather in [False, True]:
+            self._test_transformer_parity_dynamic(enable_fsdp_fp8_all_gather)
 
-    def _test_transformer_parity_dynamic(self, use_fsdp_fp8_all_gather: bool):
+    def _test_transformer_parity_dynamic(self, enable_fsdp_fp8_all_gather: bool):
         # NOTE: Weight-tying does not compose with fp8 all-gather because the
         # embedding weight and output linear weight are tied but only the
         # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
         # fp8 for that tied weight, incorrectly using fp8 for the embedding.
-        weight_tying = not use_fsdp_fp8_all_gather
+        weight_tying = not enable_fsdp_fp8_all_gather
         module = self.init_transformer(weight_tying=weight_tying)
         ref_module = copy.deepcopy(module)
         ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
-        module = self.swap_linear_with_dynamic(
-            module, use_fsdp_fp8_all_gather=use_fsdp_fp8_all_gather
-        )
+        with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
+            module = self.swap_linear_with_dynamic(module)
         for submodule in module.modules():
             if isinstance(submodule, TransformerBlock):
                 fully_shard(submodule)
@@ -109,11 +110,10 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
     @skip_if_lt_x_gpu(2)
     def test_transformer_memory(self):
         """Tests peak active memory in the forward and backward passes."""
-        # for use_fsdp_fp8_all_gather in [False, True]:
-        for use_fsdp_fp8_all_gather in [True]:
-            self._test_transformer_memory(use_fsdp_fp8_all_gather)
+        for enable_fsdp_fp8_all_gather in [False, True]:
+            self._test_transformer_memory(enable_fsdp_fp8_all_gather)
 
-    def _test_transformer_memory(self, use_fsdp_fp8_all_gather: bool):
+    def _test_transformer_memory(self, enable_fsdp_fp8_all_gather: bool):
         torch.manual_seed(42)
         # Pre-run a linear forward (gemm and bias) and backward (gemm) to
         # allocate the cuBLAS workspaces before measuring the memory usage
@@ -135,9 +135,8 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         model = Transformer(model_args)
         # Emulate the fp8 matmul to bypass the scaled matmul op's divisibility
         # requirement to use a smaller activation size
-        model = self.swap_linear_with_dynamic(
-            model, use_fsdp_fp8_all_gather=use_fsdp_fp8_all_gather, emulate=True
-        )
+        with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
+            model = self.swap_linear_with_dynamic(model, emulate=True)
         model_unsharded_numel = sum(p.numel() for p in model.parameters())
         model_sharded_numel = (model_unsharded_numel + 1) // 2
         block_lin_weight_numel = 0
@@ -181,7 +180,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         # number is kept much smaller than the actual memory usage, which is on
         # the order of 100-200+ MB)
         buffer_mb = 16
-        if use_fsdp_fp8_all_gather:
+        if enable_fsdp_fp8_all_gather:
             # Non-block parameters (fp32), 3x block non-linear-weight
             # parameters (fp32) and block linear-weight parameters (fp8)
             # (current all-gather, copy-out, and next all-gather), and other
@@ -205,7 +204,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         # Backward:
         loss.sum().backward()
         mem_mb = self._get_peak_active_memory_mb()
-        if use_fsdp_fp8_all_gather:
+        if enable_fsdp_fp8_all_gather:
             # Non-block parameters (fp32), 2x block non-linear weight
             # parameters (fp32) and block linear-weight parameters (fp8)
             # (current copy-out and next all-gather), 1x block gradients (fp32)
@@ -243,12 +242,12 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         tensor_cls = Float8DynamicLinearWeightTensor
         # Check for a single FSDP paramter group
         module_fp32 = self.init_single_module()
-        module = swap_linear_with_float8_linear(
-            module_fp32,
-            Float8DynamicLinear,
-            emulate=True,
-            use_fsdp_fp8_all_gather=True,
-        )
+        with set_enable_fsdp_fp8_all_gather(True):
+            module = swap_linear_with_float8_linear(
+                module_fp32,
+                Float8DynamicLinear,
+                emulate=True,
+            )
         self.assertIsInstance(module.weight, tensor_cls)
         fully_shard(module)
         for param_name, param in module.named_parameters():
@@ -258,12 +257,12 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
 
         # Check for multiple FSDP paramter groups
         module = self.init_multi_module()
-        module = swap_linear_with_float8_linear(
-            module,
-            Float8DynamicLinear,
-            emulate=True,
-            use_fsdp_fp8_all_gather=True,
-        )
+        with set_enable_fsdp_fp8_all_gather(True):
+            module = swap_linear_with_float8_linear(
+                module,
+                Float8DynamicLinear,
+                emulate=True,
+            )
         for param_name, param in module.named_parameters():
             if "weight" in param_name:
                 self.assertIsInstance(param, tensor_cls)
@@ -309,9 +308,8 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         # - Check for a single FSDP parameter group
         module_fp32 = self.init_single_module()
         ref_module = copy.deepcopy(module_fp32)
-        module = self.swap_linear_with_dynamic(
-            module_fp32, use_fsdp_fp8_all_gather=True
-        )
+        with set_enable_fsdp_fp8_all_gather(True):
+            module = self.swap_linear_with_dynamic(module_fp32)
         fully_shard(module)
         local_inp = self.get_local_inp()
         expected_all_gather_size = get_expected_all_gather_size(ref_module)
@@ -338,7 +336,8 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         # - Check for multiple FSDP parameter groups
         module = self.init_multi_module()
         ref_module = copy.deepcopy(module)
-        module = self.swap_linear_with_dynamic(module, use_fsdp_fp8_all_gather=True)
+        with set_enable_fsdp_fp8_all_gather(True):
+            module = self.swap_linear_with_dynamic(module)
         for submodule in module:
             fully_shard(submodule)
         fully_shard(module)
@@ -360,13 +359,12 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         Tests numeric parity for fp32 parameters with fp8 computation with a
         single module/FSDP communication group.
         """
-        for use_fsdp_fp8_all_gather in [False, True]:
+        for enable_fsdp_fp8_all_gather in [False, True]:
             module_fp32 = self.init_single_module()
             ref_module = self.swap_linear_with_dynamic(copy.deepcopy(module_fp32))
             ref_module = ref_module.cuda()
-            module = self.swap_linear_with_dynamic(
-                module_fp32, use_fsdp_fp8_all_gather=use_fsdp_fp8_all_gather
-            )
+            with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
+                module = self.swap_linear_with_dynamic(module_fp32)
             fully_shard(module)
             ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
@@ -387,13 +385,12 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         Tests numeric parity for fp32 parameters with fp8 computation with
         multiple modules/FSDP communication groups.
         """
-        for use_fsdp_fp8_all_gather in [False, True]:
+        for enable_fsdp_fp8_all_gather in [False, True]:
             module = self.init_multi_module()
             ref_module = copy.deepcopy(module)
             ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
-            module = self.swap_linear_with_dynamic(
-                module, use_fsdp_fp8_all_gather=use_fsdp_fp8_all_gather
-            )
+            with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
+                module = self.swap_linear_with_dynamic(module)
             for submodule in module:
                 fully_shard(submodule)
             fully_shard(module)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #252
* __->__ #247

This PR requires https://github.com/pytorch/pytorch/pull/122908.

This PR adds an option for FSDP fp8 all-gather with FSDP2, focusing on correctness first.
- We add a config option `enable_fsdp_fp8_all_gather: bool = False` in `float8_experimental.config` that can be set to `True` to enable the new behavior.
- We only support `Float8DynamicLinear` for now.
- For the fp8 all-gather, we make `Float8DynamicLinear.weight` to be a tensor subclass `Float8DynamicLinearWeightTensor`. This can be thought of as a `torch.Tensor` weight that knows how to cast itself to fp8. Since the cast logic is specific to dynamic scaling (i.e. it would not be the exact same for delayed scaling), I preferred to simply name the subclass `Float8DynamicLinearWeightTensor`.
- The subclass is a `__torch_dispatch__` wrapper subclass since that is the kind of subclass most compatible with `torch.compile`.
- The subclass defines `fsdp_pre_all_gather()` and `fsdp_post_all_gather()` to implement the fp8 all-gather.
- We include unit testing that covers eager-mode correctness and memory usage.

Differential Revision: [D56192107](https://our.internmc.facebook.com/intern/diff/D56192107)