### PR TITLE
make the backward of differentiable float8 casts pass gradient as is

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pytest test/test_compile.py
 ./test/test_tp.sh
 
 # run all of these tests
-./test/run_everything.sh
+./test/test_everything.sh
 ```
 
 # Benchmarking


### PR DESCRIPTION
Summary:

Behavior before:
* high precision to float8 in fw, float8 to high precision in bw
* float8 to high precision in fw, high precision to float8 in bw if grad is a Float8Tensor, pass gradient unchanged otherwise

Behavior after:
* high precision to float8 in fw, pass gradient unchanged in bw
* float8 to high precision in fw, pass gradient unchanged in bw

Motivation for the new state:
1. we want gradients to be in high precision unless specified otherwise by the float8 recipe, and the logic to specify grad casting to float8 before the matmul is better implemented elsewhere
2. there is actually no logic change in this diff as the backward casts were not getting hit from existing code, this diff just makes the intended behavior clearer

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: