### PR TITLE
delayed scaling: stop syncing weight amax values across ranks

### DIFF
--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -25,7 +25,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 torch.manual_seed(0)
 
 # TODO: Add more shapes for the benchmark
-B, M, K, N = 32, 32, 32, 32
+B, M, K, N = 32, 1024, 1024, 1024
 lr = 0.01
 
 
@@ -152,8 +152,7 @@ def fsdp_main(rank, world_size, args):
     cleanup()
 
 
-def run():
-    compile = True
+def run(compile: bool):
     base_dtype = torch.bfloat16
     WORLD_SIZE = torch.cuda.device_count()
     print(f"{base_dtype = }")

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -265,8 +265,7 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
             # Note: do not reduce the weight values, because FSDP already ensures
             # the weight values on all ranks are the same.
             all_amax_tensors = torch.cat(
-                fp8_amax_x_tensor_list
-                + fp8_amax_dL_dY_tensor_list
+                fp8_amax_x_tensor_list + fp8_amax_dL_dY_tensor_list
             )
             all_reduced_amax_tensor = all_reduce(
                 all_amax_tensors, "MAX", list(range(dist.get_world_size()))

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -263,7 +263,7 @@ def sync_float8_amax_and_scale_history(model: torch.nn.Module, fp8_layers=None) 
         if dist.is_initialized():
             # Combine all the amax tensors into one tensor and reduce it
             # Note: do not reduce the weight values, because FSDP already ensures
-            # the weight values on all ranks are the same.
+            # the weight values on all ranks are the same after all-gather.
             all_amax_tensors = torch.cat(
                 fp8_amax_x_tensor_list + fp8_amax_dL_dY_tensor_list
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #273
* __->__ #272
* #271

Summary:

FSDP already ensures that each rank receives the same weight, so the
amaxes of weights are the same on each rank.

I checked performance before/after on the multi GPU benchmark and
didn't see a significant impact on the toy model, but less comms value is better.

Test Plan:

./test_everything.sh passes

Reviewers:

Subscribers:

Tasks:

Tags: