### PR TITLE
add norm_ffn_norm to profile script

### DIFF
--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -391,6 +391,11 @@ def main(
             "bw_gpbs",
         ],
     )
+    df.sort_values(
+        ["experiment", "category", "pct_gpu_time"],
+        ascending=[True, True, False],
+        inplace=True,
+    )
     print("\nSummary of GPU time by CPU kernel\n\n", df)
 
     # compare gemm and overhead time

--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -14,6 +14,8 @@ from typing import Callable, Optional
 import fire
 
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_linear_utils import (
@@ -35,6 +37,105 @@ class LNLinear(torch.nn.Module):
     def forward(self, x):
         x = self.ln(x)
         x = self.fc(x)
+        return x
+
+
+# copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/norms.py
+class RMSNorm(nn.Module):
+    """
+    Initialize the RMSNorm normalization layer.
+
+    Args:
+        dim (int): The dimension of the input tensor.
+        eps (float, optional): A small value added to the denominator for numerical stability. Default is 1e-6.
+
+    Attributes:
+        eps (float): A small value added to the denominator for numerical stability.
+        weight (nn.Parameter): Learnable scaling parameter.
+
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x: torch.Tensor):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x: torch.Tensor):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+    def reset_parameters(self):
+        torch.nn.init.ones_(self.weight)  # type: ignore
+
+
+# copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py
+class FeedForward(nn.Module):
+    """
+    FeedForward module
+
+    Args:
+        dim (int): Input dimension.
+        hidden_dim (int): Hidden dimension of the feedforward layer.
+        multiple_of (int): Value to ensure hidden dimension is a multiple of this value.
+        ffn_dim_multiplier (Optional[float]): Custom multiplier for hidden dimension. Defaults to None.
+
+    Attributes:
+        w1 (Linear): Linear transformation for the first layer.
+        w2 (Linear): Linear transformation for the second layer.
+        w3 (Linear): Linear transformation for the third layer.
+
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        multiple_of: int,
+        ffn_dim_multiplier: Optional[float],
+    ):
+        super().__init__()
+        hidden_dim = int(2 * hidden_dim / 3)
+        # custom dim factor multiplier
+        if ffn_dim_multiplier is not None:
+            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.w1.weight, mean=0.0, std=0.02)
+        for linear in (self.w2, self.w3):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
+
+
+class NormFFNResidualNorm(nn.Module):
+    """
+    A fragment representing the end of TransformerBlock n and the start
+    of TransformerBlock n + 1, intended to include the fusions relevant
+    to float8 gemms in the FFN module in forward and backward.
+    """
+
+    def __init__(self, dim, hidden_dim, multiple_of, ffn_dim_multiplier):
+        super().__init__()
+        self.ffn_norm = RMSNorm(dim)
+        self.ffn = FeedForward(dim, hidden_dim, multiple_of, ffn_dim_multiplier)
+        self.attn_norm = RMSNorm(dim)
+
+    def forward(self, h):
+        # end of transformer block n
+        x = self.ffn_norm(h)
+        x = self.ffn(x)
+        x = h + x
+        # start of transformer block n + 1
+        x = self.attn_norm(x)
         return x
 
 
@@ -93,40 +194,46 @@ def profile_function(
     return prof
 
 
-@dataclass(frozen=True)
-class ModelParams:
-    M: int
-    K: int
-    N: int
-    ref_dtype: torch.dtype
-    layer_norm: bool = True
-
-
 def main(
     profile_path_prefix: Path,
     compile: bool = True,
     linear_type: str = "dynamic",
-    use_layer_norm: bool = False,
+    model_type: str = "linear",
 ):
-    params = ModelParams(
-        M=4 * 4096,
-        K=8192,
-        N=7168,
-        ref_dtype=torch.bfloat16,
-        layer_norm=use_layer_norm,
-    )
+    assert model_type in ("linear", "ln_linear", "norm_ffn_norm"), "unsupported"
+
     print(f"Compile is set to          | {compile}")
     print(f"Using Linear type:         | {linear_type}")
-    print(f"Use layer norm is set to   | {params.layer_norm}")
+    print(f"model_type is set to       | {model_type}")
 
     device = "cuda"
-    if params.layer_norm:
-        m_ref = LNLinear(params.K, params.N)
-    else:
-        m_ref = torch.nn.Sequential(
-            torch.nn.Linear(params.K, params.N, bias=False),
+    ref_dtype = torch.bfloat16
+    if model_type == "ln_linear":
+        M, K, N = 4 * 4096, 8192, 7168
+        m_ref = LNLinear(K, N)
+        input_tensor = torch.randn(
+            M, K, device=device, dtype=ref_dtype, requires_grad=True
         )
-    m_ref = m_ref.to(device).to(params.ref_dtype)
+    elif model_type == "norm_ffn_norm":
+        m_ref = NormFFNResidualNorm(
+            dim=4096,
+            hidden_dim=16384,
+            multiple_of=1024,
+            ffn_dim_multiplier=1.3,
+        )
+        input_tensor = torch.randn(
+            1, 8192, 4096, device=device, dtype=ref_dtype
+        ).requires_grad_()
+    else:
+        M, K, N = 4 * 4096, 8192, 7168
+        m_ref = torch.nn.Sequential(
+            torch.nn.Linear(K, N, bias=False),
+        )
+        input_tensor = torch.randn(
+            M, K, device=device, dtype=ref_dtype, requires_grad=True
+        )
+
+    m_ref = m_ref.to(device).to(ref_dtype)
 
     linear_type = LinearType[linear_type.upper()]
     linear_cls = (
@@ -135,10 +242,6 @@ def main(
 
     m_float8 = copy.deepcopy(m_ref)
     swap_linear_with_float8_linear(m_float8, linear_cls)
-
-    input_tensor = torch.randn(
-        params.M, params.K, device="cuda", dtype=params.ref_dtype, requires_grad=True
-    )
 
     def ref_forw_backward(x):
         out = m_ref(x)
@@ -173,14 +276,14 @@ def main(
         float8_forw_backward_wrapper(input_tensor)
 
     # Profile Reference Model
-    ref_suffix = f"_ref_compile_{compile}.json"
+    ref_suffix = f"_{model_type}_ref_compile_{compile}.json"
     profile_config = ProfileConfig(
         profile_path_prefix + ref_suffix, ref_suffix, iters=5, warmup_iters=5, sync=True
     )
     profile_function(profile_config, ref_forw_backward, input_tensor)
 
     # Profile Float8 Model
-    float8_suffix = f"_float8_compile_{compile}_{linear_type}.json"
+    float8_suffix = f"_{model_type}_float8_compile_{compile}_{linear_type}.json"
     profile_config = ProfileConfig(
         profile_path_prefix + float8_suffix,
         float8_suffix,

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -6,6 +6,7 @@
 
 import collections
 import json
+import re
 
 
 def profiler_output_to_time_by_kernel_name(prof):
@@ -68,3 +69,16 @@ def kernel_name_to_category(k):
         # positives if model code contains other code to abs/max/clamp
         return "1_f8_overhead"
     return "2_other"
+
+
+def parse_bw_and_kernel_name(line):
+    """
+    Input: a single line of stdout of TORCHINDUCTOR_PROFILE=1 output, such as
+        0.257ms         0.537 GB         2092.43GB/s     triton_red_fused_native_layer_norm_0
+    Output: the bandwidth value and the kernel name, or None and None
+    """
+    result = re.search(".* ([0-9\.]+)GB/s.*(triton_[a-z_0-9]+)", line)
+    if result:
+        return result.group(1), result.group(2)
+    else:
+        return None, None

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import collections
+import json
+
+
+def profiler_output_to_time_by_kernel_name(prof):
+    """
+    Input: a profiler with captured events.
+    Output: a deduplicated list of GPU time in nanoseconds grouped by CPU kernel name
+
+    Note that if there are user_annotations in the captured events, `torch.profiler`
+    will include their time in the total GPU time displayed at the bottom of
+    `key_averages.table()`. The filter below excludes them to prevent double
+    counting.
+    """
+    key_averages = prof.key_averages()
+    thresh = 1e-10
+    kernel_name_to_gpu_time_us = collections.defaultdict(float)
+    for e in key_averages:
+        # manually filter top-level CPU events with attributed CUDA time
+        # example CPU event row:
+        #                                               aten::addmm         0.83%      76.554us         0.98%      90.846us      90.846us       1.022ms        31.82%       1.022ms       1.022ms             1
+        # and it maps to this CUDA event:
+        #   sm80_xmma_gemm_f32f32_f32f32_f32_tn_n_tilesize256x64...         0.00%       0.000us         0.00%       0.000us       0.000us       1.022ms        31.82%       1.022ms       1.022ms             1
+        if not (e.self_cpu_time_total > thresh and e.self_device_time_total > thresh):
+            continue
+        kernel_name_to_gpu_time_us[e.key] = e.self_device_time_total
+    return kernel_name_to_gpu_time_us
+
+
+def profiler_output_to_gpu_time_for_key(prof, key):
+    """
+    Input: an event name
+    Output: sum of GPU time of all events with that name in `prof`
+
+    This is useful to get the total time of a user annotation
+    """
+    total = 0
+    for e in prof.profiler.function_events:
+        if e.key == key:
+            total += e.device_time_total
+    return total


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #282
* #281

Summary:

This PR adds an example FFN with the preceding and subsequent norms
to the profile script. It also adds a couple of automatic data exctration QOL
items:
1. extract GPU time and aggregate it per CPU kernel name
2. attribute the kernel GPU time to gemms, float8 overhead or other
3. approximate the time spent syncing scales/amaxes and display as pct of total time
4. if TORCHINDUCTOR_PROFILE env variable is set, also parses its output for triton kernel memory bandwidth

I hope for this to speed up debugging of kernel performance on various models, as this automates a lot of high level metrics which take more time to get from visualizing the traces.

Example output when testing `norm_ffn_norm` with dynamic scaling and compile, and bandwidth measurements on

```
Summary of GPU time by CPU kernel

    experiment                                                                                      kernel       category  time_ms  pct_gpu_time  bw_gpbs
1       0_ref                                                                                    aten::mm         0_gemm   15.625         0.826     None
9       0_ref                                                     triton_red_fused__to_copy_add_mul_sum_2        2_other    1.375         0.073   241.12
11      0_ref                                                                                  aten::add_        2_other    0.566         0.030     None
8       0_ref                                            triton_poi_fused_add_fill_mul_sigmoid_silu_sub_1        2_other    0.520         0.027  2203.88
2       0_ref                                                                 triton_poi_fused_mul_silu_1        2_other    0.302         0.016  2207.31
10      0_ref                                             triton_red_fused__to_copy_add_div_mul_pow_sum_3        2_other    0.150         0.008  1375.62
7       0_ref                                             triton_red_fused__to_copy_add_div_mul_pow_sum_0        2_other    0.122         0.006  1963.47
3       0_ref                                          triton_red_fused__to_copy_add_mean_mul_pow_rsqrt_2        2_other    0.084         0.004  1935.35
6       0_ref                                                                                 aten::copy_        2_other    0.060         0.003     None
0       0_ref                                          triton_red_fused__to_copy_add_mean_mul_pow_rsqrt_0        2_other    0.052         0.003  1861.85
4       0_ref                                                                                   aten::sum        2_other    0.051         0.003     None
5       0_ref                                                                                 aten::fill_        2_other    0.002         0.000     None
19   1_float8                                                                            aten::_scaled_mm         0_gemm    8.148         0.623     None
36   1_float8  triton_poi_fused__to_copy_add_clamp_copy_empty_like_fill_mul_reciprocal_sigmoid_silu_sub_6  1_f8_overhead    0.408         0.031  2220.22
34   1_float8                                    triton_red_fused_abs_add_fill_max_mul_sigmoid_silu_sub_4  1_f8_overhead    0.314         0.024  2090.00
18   1_float8                                                         triton_poi_fused__scaled_mm_clone_6  1_f8_overhead    0.294         0.022  1439.36
37   1_float8                               triton_poi_fused__scaled_mm_clamp_clone_copy_mul_reciprocal_7  1_f8_overhead    0.292         0.022  1527.26
22   1_float8                                  triton_poi_fused__to_copy_clamp_copy_mul_reciprocal_silu_9  1_f8_overhead    0.255         0.020  2148.34
20   1_float8                                                         triton_red_fused_abs_max_mul_silu_7  1_f8_overhead    0.244         0.019  1834.33
23   1_float8                                                        triton_poi_fused__scaled_mm_clone_10  1_f8_overhead    0.146         0.011  1462.59
15   1_float8                                                                  triton_red_fused_abs_max_3  1_f8_overhead    0.127         0.010  1498.30
31   1_float8                                     triton_red_fused__to_copy_abs_add_div_max_mul_pow_sum_1  1_f8_overhead    0.091         0.007  1971.11
33   1_float8                               triton_poi_fused__scaled_mm_clamp_clone_copy_mul_reciprocal_3  1_f8_overhead    0.090         0.007  1388.84
21   1_float8                                                                  triton_red_fused_abs_max_8  1_f8_overhead    0.062         0.005  1487.67
17   1_float8                                       triton_poi_fused__to_copy_clamp_copy_mul_reciprocal_5  1_f8_overhead    0.046         0.003  1833.92
12   1_float8                                  triton_red_fused__to_copy_abs_add_max_mean_mul_pow_rsqrt_0  1_f8_overhead    0.044         0.003  1246.58
16   1_float8                                        triton_per_fused_abs_clamp_copy_max_mul_reciprocal_4  1_f8_overhead    0.010         0.001     0.32
35   1_float8                  triton_per_fused__scaled_mm_abs_clamp_clone_copy_max_mul_reciprocal_silu_5  1_f8_overhead    0.005         0.000     0.32
32   1_float8                       triton_red_fused__scaled_mm_abs_clamp_clone_copy_max_mul_reciprocal_2  1_f8_overhead    0.003         0.000     4.51
13   1_float8                               triton_red_fused__to_copy_abs_clamp_copy_max_mul_reciprocal_1  1_f8_overhead    0.003         0.000     4.61
38   1_float8                                                     triton_red_fused__to_copy_add_mul_sum_8        2_other    0.804         0.061   244.46
40   1_float8                                                                                  aten::add_        2_other    0.567         0.043     None
30   1_float8                                                         triton_red_fused__to_copy_mul_sum_0        2_other    0.562         0.043   236.73
39   1_float8                                             triton_red_fused__to_copy_add_div_mul_pow_sum_9        2_other    0.149         0.011  1377.16
25   1_float8                                                                   triton_poi_fused_clone_12        2_other    0.146         0.011  1532.05
24   1_float8                                         triton_red_fused__to_copy_add_mean_mul_pow_rsqrt_11        2_other    0.115         0.009  1293.20
29   1_float8                                                                                 aten::copy_        2_other    0.060         0.005     None
27   1_float8                                                                                   aten::sum        2_other    0.050         0.004     None
26   1_float8                                                                   triton_poi_fused_clone_13        2_other    0.043         0.003  1333.22
14   1_float8                                                               triton_poi_fused_empty_like_2        2_other    0.002         0.000     0.00
28   1_float8                                                                                 aten::fill_        2_other    0.002         0.000     None

Float8 amax/scale sync approx ratio of total time: 0.000

Summary of time (ms) by kernel category

 experiment     0_ref  1_float8  f8_div_ref  ref_div_f8
category                                              
0_gemm        15.625     8.148       0.521       1.918
1_f8_overhead  0.000     2.436         inf       0.000
2_other        3.283     2.498       0.761       1.314
All           18.908    13.082       0.692       1.445

```

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59163495](https://our.internmc.facebook.com/intern/diff/D59163495)