### PR TITLE
Adding Float8 Linear variants supporting inference-only with lower overhead

### DIFF
--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
-from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear import Float8Linear, Float8SWLinear, Float8DASWLinear
 from float8_experimental.float8_tensor import Float8Tensor
 
-__all__ = ["Float8Tensor", "Float8Linear"]
+__all__ = ["Float8Tensor", "Float8Linear", "Float8SWLinear", "Float8DASWLinear"]


### PR DESCRIPTION
The changes include two new Float8 Linear implementations that removes some extra wiring in `Float8Linear` unnecessary for inference-only use cases to result in lower latency.

- `Float8SWLinear` supports direct fp8 type direct downcast for activation, and Static per-tensor scale for Weight. Our analysis shows that using this results in no loss of accuracy in Llama models.
- `Float8DASWLinear` supports Dynamic per-tensor scale for Activation, and Static per-tensor scale for Weight. This is used when activation tensor requires dynamic scaling. Compared to `Float8SWLinear`, this has higher overhead introduced by dynamic activation tensor scale calculation. The overhead can be mitigated when used with `torch.compile`.

cc: @ani300