### PR TITLE
[ROCm] Unskip passing torch.compile test

### DIFF
--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -22,7 +22,7 @@ from float8_experimental.float8_linear_utils import (
     sync_float8_amax_and_scale_history,
 )
 from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
-from float8_experimental.float8_utils import e4m3_dtype, IS_ROCM
+from float8_experimental.float8_utils import e4m3_dtype
 
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
@@ -128,14 +128,12 @@ class TestGraphBreaks(DynamoTestCase):
             return x_fp8
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    @unittest.skipIf(IS_ROCM, "test doesn't currently work on the ROCm stack")
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8Tensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
         mod = self.MockLinear(graph_break=True).cuda()
         compiled_mod = copy.deepcopy(mod)
         compiled_mod = torch.compile(compiled_mod, backend=cnts)
-        torch.manual_seed(0)
         x = torch.randn(16, 16, device="cuda")
         y_eager = mod(x)
         y_compiled = compiled_mod(x)


### PR DESCRIPTION
@drisspg Looks like this test was originally failing on my end due to an environmental issue. Pushing this, and assuming it passes internal CI, should be fine