### PR TITLE
Add a Float8LinearInference module to support static, dynamic, and wo quant

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip3 install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         pip install -e .
         pip install -e .'[dev]'
         pip install -e .'[test]'

--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -21,7 +21,6 @@ import torch.nn.functional as F
 from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_linear_utils import (
-    get_float8_linear,
     linear_requires_sync,
     LinearType,
     swap_linear_with_float8_linear,

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import collections
-import json
 import re
 
 

--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
 from float8_experimental.float8_linear import Float8Linear
-from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
+
+# Needed to load Float8Tensor with weights_only = True
+from torch.serialization import add_safe_globals
+
+add_safe_globals([Float8Tensor, ScaledMMConfig])
 
 __all__ = ["Float8Tensor", "Float8Linear"]

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -80,8 +80,12 @@ class Float8DynamicLinear(torch.nn.Linear):
             return cls(in_features=in_features, out_features=out_features, bias=False)
 
     def set_mm_configs(self, emulate: bool) -> "Float8DynamicLinear":
-        self.forward_config = ScaledMMConfig(emulate, not emulate, pad_inner_dim=config.pad_inner_dim)
-        self.backward_config = ScaledMMConfig(emulate, False, pad_inner_dim=config.pad_inner_dim)
+        self.forward_config = ScaledMMConfig(
+            emulate, not emulate, pad_inner_dim=config.pad_inner_dim
+        )
+        self.backward_config = ScaledMMConfig(
+            emulate, False, pad_inner_dim=config.pad_inner_dim
+        )
         return self
 
     def set_weight_and_bias(

--- a/float8_experimental/float8_dynamic_linear.py
+++ b/float8_experimental/float8_dynamic_linear.py
@@ -62,8 +62,8 @@ class Float8DynamicLinear(torch.nn.Linear):
     def __init__(self, **super_kwargs):
         super().__init__(**super_kwargs)
 
-    def forward(self, x):
-        x_fp8 = cast_to_float8_e4m3fn(x, self.forward_config)
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        x_fp8 = cast_to_float8_e4m3fn(input, self.forward_config)
         if isinstance(self.weight, Float8Tensor):  # cast by FSDP
             w_fp8 = self.weight
         else:
@@ -73,7 +73,35 @@ class Float8DynamicLinear(torch.nn.Linear):
         return y
 
     @classmethod
-    def from_float(cls, mod, emulate: bool = False) -> "Float8DynamicLinear":
+    def create_meta_class(
+        cls, in_features: int, out_features: int
+    ) -> "Float8DynamicLinear":
+        with torch.device("meta"):
+            return cls(in_features=in_features, out_features=out_features, bias=False)
+
+    def set_mm_configs(self, emulate: bool) -> "Float8DynamicLinear":
+        self.forward_config = ScaledMMConfig(emulate, not emulate, pad_inner_dim=config.pad_inner_dim)
+        self.backward_config = ScaledMMConfig(emulate, False, pad_inner_dim=config.pad_inner_dim)
+        return self
+
+    def set_weight_and_bias(
+        self, weight: torch.nn.Parameter, bias: Optional[torch.nn.Parameter]
+    ) -> "Float8DynamicLinear":
+        if config.enable_fsdp_fp8_all_gather:
+            self.weight = nn.Parameter(
+                WeightWithDynamicFloat8CastTensor(weight, self.forward_config)
+            )
+        else:
+            self.weight = weight
+        self.bias = bias
+        return self
+
+    @classmethod
+    def from_float(
+        cls,
+        mod,
+        emulate: bool = False,
+    ) -> "Float8DynamicLinear":
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
 
@@ -81,39 +109,31 @@ class Float8DynamicLinear(torch.nn.Linear):
             mod (torch.nn.Linear): nn.Linear to convert
             emulate (bool): whether to emulate fp8 matmul logic in float32
         """
-        with torch.device("meta"):
-            super_kwargs = {
-                "in_features": mod.in_features,
-                "out_features": mod.out_features,
-                "bias": False,
-            }
-            new_mod = cls(**super_kwargs)
-
-        new_mod.forward_config = ScaledMMConfig(
-            emulate=emulate,
-            use_fast_accum=not bool(emulate),
-            fp8_output=False,
-            pad_inner_dim=config.pad_inner_dim,
+        return (
+            cls.create_meta_class(mod.in_features, mod.out_features)
+            .set_mm_configs(emulate)
+            .set_weight_and_bias(mod.weight, mod.bias)
         )
-        new_mod.backward_config = ScaledMMConfig(
-            emulate=emulate,
-            use_fast_accum=False,
-            fp8_output=False,
-            pad_inner_dim=config.pad_inner_dim,
-        )
-        if config.enable_fsdp_fp8_all_gather:
-            new_mod.weight = nn.Parameter(
-                WeightWithDynamicFloat8CastTensor(mod.weight, new_mod.forward_config)
-            )
-        else:
-            new_mod.weight = mod.weight
-        new_mod.bias = mod.bias
-        return new_mod
 
 
 def cast_to_float8_e4m3fn(
-    inpt_tensor: torch.Tensor, mm_config: ScaledMMConfig, reduce_amax: bool = False
+    inpt_tensor: torch.Tensor,
+    mm_config: ScaledMMConfig,
+    reduce_amax: bool = False,
 ) -> Float8Tensor:
+    """Casts an input tensor to the Float8 (e4m3fn) format for efficient computation.
+
+    Args:
+        inpt_tensor: The input tensor to be cast.
+        mm_config: Configuration settings for the matrix multiplication
+        reduce_amax: Whether to reduce the amax (absolute maximum) among the local distributed group.
+
+    Returns:
+        Float8Tensor: The input tensor cast to Float8 (e4m3fn) format.
+
+    Note:
+        If the input tensor is already in Float8 format, it is returned as is without re-casting.
+    """
     if tensor_already_casted_to_fp8(inpt_tensor):
         return inpt_tensor
     scale = tensor_to_scale(inpt_tensor, e4m3_dtype, reduce_amax)

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -312,10 +312,10 @@ class Float8Linear(torch.nn.Linear):
         self.is_amax_initialized = True
         self.amax_and_scale_synced = False
 
-    def forward(self, x):
-        self.float8_pre_forward(x)
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self.float8_pre_forward(input)
 
-        x_fp8 = self.cast_x_to_float8(x, self.is_amax_initialized)
+        x_fp8 = self.cast_x_to_float8(input, self.is_amax_initialized)
         w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
 
         y = torch.matmul(x_fp8, w_fp8.t())

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -103,7 +103,7 @@ def swap_linear_layers(
     *,
     skip_fqn_list: Optional[List[str]] = None,
     linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
-) -> nn.Module:
+) -> Optional[nn.Module]:
     """
     Generic function to swap linear layers in a module with a new type of linear layer.
 
@@ -174,7 +174,7 @@ def swap_linear_with_float8_linear(
     skip_fqn_list: Optional[List[str]] = None,
     emulate: bool = False,
     linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
-) -> nn.Module:
+) -> Optional[nn.Module]:
     return swap_linear_layers(
         module,
         lambda m: module_cls.from_float(m, emulate=emulate),

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -6,7 +6,7 @@
 import copy
 import logging
 from enum import auto, Enum
-from typing import Callable, List, Optional, Type
+from typing import Callable, List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -97,28 +97,33 @@ def filter_out_small_unaligned_layers(size_limit: int) -> Callable[[nn.Linear], 
     )
 
 
-def swap_linear_with_float8_linear(
+def swap_linear_layers(
     module: nn.Module,
-    module_cls: Type[nn.Module],
+    from_float_func: Callable[[nn.Linear], nn.Linear],
     *,
     skip_fqn_list: Optional[List[str]] = None,
-    emulate: bool = False,
     linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
 ) -> nn.Module:
     """
-    Replaces all instances of ``torch.nn.Linear`` in ``module`` with instances
-    of ``module_cls`` (either ``Float8Linear`` or ``Float8DynamicLinear``).
+    Generic function to swap linear layers in a module with a new type of linear layer.
+
+    Note:
+        If applied to a root-level nn.Linear, the module will not be modified in place
+        and returned instead
 
     Args:
-        module (torch.nn.Module): Module to modify.
-        module_cls (Union[Type[Float8Linear], Type[Float8DynamicLinear]]): Float8 linear class for the swap.
-        skip_fqn_list (List[str], optional): If specified, a list of module FQNs to skip.
-            Linear submodules of these skipped modules will also be skipped.
-        emulate (bool): Whether to emulate the fp8 matmul logic in fp32.
-        linear_layer_filter (Optional[Callable[[nn.Linear], bool]]): If specified, only the linear layers
+        module: Module to modify.
+        from_float_func: Function that accepts a linear layer and returns a new type of linear layer.
+        skip_fqn_list: If specified, a list of module FQNs to skip.
+        linear_layer_filter: If specified, only the linear layers
             that pass the filter function will be swapped.
+        from_float_kwargs: Additional keyword arguments for from_float_func.
+
+    Returns:
+     nn.Module: The modified module with swapped linear layers.
     """
     module_names_to_skip = set(skip_fqn_list or [])
+
     if isinstance(module, nn.Linear) and (
         linear_layer_filter is None or linear_layer_filter(module)
     ):
@@ -126,16 +131,17 @@ def swap_linear_with_float8_linear(
             raise AssertionError(
                 f"Does not support a root nn.Linear with children: {module}"
             )
-        return module_cls.from_float(module, emulate=emulate)
+        return from_float_func(
+            module,
+        )
 
-    # Mark all modules to skip as visited
     root_module = module
     visited_modules = {root_module}
+
     for module_name, module in root_module.named_modules():
         if module_name in module_names_to_skip:
             visited_modules.add(module)
 
-    # Run a post-order traversal to swap linears
     def post_order_traversal(
         module: nn.Module, module_name: str, parent_module: Optional[nn.Module]
     ):
@@ -144,20 +150,37 @@ def swap_linear_with_float8_linear(
             if child_module not in visited_modules:
                 visited_modules.add(child_module)
                 post_order_traversal(child_module, child_module_name, module)
+
         if isinstance(module, nn.Linear) and (
             linear_layer_filter is None or linear_layer_filter(module)
         ):
             assert (
                 parent_module is not None
             ), f"Linear root module should return early: {module}"
-            float8linear_module = module_cls.from_float(module, emulate=emulate)
-            setattr(parent_module, module_name, float8linear_module)
+            new_linear_module = from_float_func(module)
+            setattr(parent_module, module_name, new_linear_module)
 
     post_order_traversal(root_module, "", None)
     # Without this explicit `del`, this set only gets deleted upon an explicit
     # garbage collection (not from when its refcount hits zero)
     del visited_modules
     return root_module
+
+
+def swap_linear_with_float8_linear(
+    module: nn.Module,
+    module_cls: Union[Float8Linear, Float8DynamicLinear],
+    *,
+    skip_fqn_list: Optional[List[str]] = None,
+    emulate: bool = False,
+    linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
+) -> nn.Module:
+    return swap_linear_layers(
+        module,
+        lambda m: module_cls.from_float(m, emulate=emulate),
+        skip_fqn_list=skip_fqn_list,
+        linear_layer_filter=linear_layer_filter,
+    )
 
 
 def get_float8_layers(model: torch.nn.Module):

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -6,7 +6,7 @@
 import copy
 import logging
 from enum import auto, Enum
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Type, Union
 
 import torch
 import torch.distributed as dist
@@ -169,7 +169,7 @@ def swap_linear_layers(
 
 def swap_linear_with_float8_linear(
     module: nn.Module,
-    module_cls: Union[Float8Linear, Float8DynamicLinear],
+    module_cls: Union[Type[Float8Linear], Type[Float8DynamicLinear]],
     *,
     skip_fqn_list: Optional[List[str]] = None,
     emulate: bool = False,

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -67,6 +67,26 @@ def float8_split(aten_op, args, kwargs=None):
     return list(out)
 
 
+@implements([aten.copy_.default])
+def copy_fp8(aten_op, args, kwargs=None):
+    self = args[0]
+    src = args[1]
+    assert isinstance(self, Float8Tensor) or isinstance(src, Float8Tensor)
+
+    self_data = self
+    if isinstance(self, Float8Tensor):
+        self_data = self._data
+
+    src_data = src
+    if isinstance(src, Float8Tensor):
+        src_data = src._data
+
+    fp8_out = aten_op(self_data, src_data, *args[2:], **kwargs)
+    if isinstance(self, Float8Tensor):
+        return Float8Tensor(fp8_out, self._scale, self._orig_dtype, self._mm_config)
+    return fp8_out
+
+
 # Errors cant `cat_cuda float8 e4m3fn`
 @implements([aten.cat.default])
 def float8_cat(aten_op, args, kwargs=None):

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -67,26 +67,6 @@ def float8_split(aten_op, args, kwargs=None):
     return list(out)
 
 
-@implements([aten.copy_.default])
-def copy_fp8(aten_op, args, kwargs=None):
-    self = args[0]
-    src = args[1]
-    assert isinstance(self, Float8Tensor) or isinstance(src, Float8Tensor)
-
-    self_data = self
-    if isinstance(self, Float8Tensor):
-        self_data = self._data
-
-    src_data = src
-    if isinstance(src, Float8Tensor):
-        src_data = src._data
-
-    fp8_out = aten_op(self_data, src_data, *args[2:], **kwargs)
-    if isinstance(self, Float8Tensor):
-        return Float8Tensor(fp8_out, self._scale, self._orig_dtype, self._mm_config)
-    return fp8_out
-
-
 # Errors cant `cat_cuda float8 e4m3fn`
 @implements([aten.cat.default])
 def float8_cat(aten_op, args, kwargs=None):

--- a/float8_experimental/float8_tensor.py
+++ b/float8_experimental/float8_tensor.py
@@ -266,6 +266,7 @@ class Float8Tensor(torch.Tensor):
             scale: the scale to use to convert the tensor
             float8_dtype: the float8 dtype to use
             amax_buffer: a buffer to store the amax value in prior to conversion
+            mm_config: Defines the configuration for the scaled_mm
 
         Returns:
             Float8Tensor: a float8 tensor

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -139,7 +139,7 @@ def to_fp8_saturated(x: torch.Tensor, float8_dtype: torch.dtype):
         raise ValueError(f"Unsupported float8_dtype: {float8_dtype}")
 
 
-def compute_error(x: torch.Tensor, y: torch.Tensor):
+def compute_error(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Computes the error between two tensors in dB.
 
     For more details see:

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -1,0 +1,220 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Defines an nn module designed to be used during inference
+"""
+from dataclasses import dataclass
+
+from enum import auto, Enum
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from float8_experimental.float8_linear_utils import swap_linear_layers
+
+from float8_experimental.float8_tensor import (
+    Float8Tensor,
+    ScaledMMConfig,
+    tensor_already_casted_to_fp8,
+    to_fp8_no_autograd,
+)
+from float8_experimental.float8_utils import e4m3_dtype, tensor_to_scale
+
+
+class ActivationCasting(Enum):
+    """Types of quantization to perform on the activations
+
+    WEIGHT_ONLY: Only quantize the weight, no activation casting, weight will be dequantized in the forward pass
+    STATIC: Activation is quantized during model initialization with a static scale
+    DYNAMIC: Activation is quantized during forward pass with a dynamic scale calculated from the input activation
+    """
+
+    WEIGHT_ONLY = auto()
+    DYNAMIC = auto()
+    STATIC = auto()
+
+
+@dataclass(frozen=True)
+class QuantConfig:
+    """Defines the configuration for the quantization to fp8 of a linear module
+
+    Args:
+        activation_casting: The type of quantization to perform on the activations
+        activation_scale: The scale of the input to this linear module, used for static quantization only
+    """
+
+    activation_casting: ActivationCasting
+    activation_scale: Optional[torch.Tensor] = None
+
+    def __post_init__(self):
+        if self.activation_casting == ActivationCasting.STATIC:
+            assert isinstance(
+                self.activation_scale, torch.Tensor
+            ), "When activation_casting is 'static', activation_scale must be a tensor."
+
+
+class Float8LinearInference(torch.nn.Linear):
+    """
+    This is a wrapper around torch.nn.Linear that supports FP8 inference
+    Supported forms of infernce:
+        - FP8 inference with fp32 matmul - weight only
+        - FP8 inference with fp8 matmul and dynamic weight casting
+        - FP8 inference with fp8 matmul and static weight casting
+    """
+
+    def __init__(self, **super_kwargs):
+        super().__init__(**super_kwargs)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.activation_casting == ActivationCasting.WEIGHT_ONLY:
+            return torch.nn.functional.linear(
+                input, self.weight.to_original_precision()
+            )
+
+        x_fp8 = cast_to_float8_e4m3fn(
+            input, self.forward_config, activation_scale=self.activation_scale
+        )
+        return torch.nn.functional.linear(x_fp8, self.weight, self.bias)
+
+    # Builder functions for Float8LinearInference
+    def quantize_weight(self, dtype: torch.dtype = e4m3_dtype) -> None:
+        """This functions converts the weight to a Float8Tensor and sets its requires_grad to False.
+
+        Args:
+            dtype: The dtype to quantize the weight to. Default is e4m3_dtype.
+
+        Note:
+            This function is typically called during inference to quantize the weight once since
+            the weight is not updated during inference.
+
+        """
+        assert not isinstance(
+            self.weight, Float8Tensor
+        ), "Weight has already been quantized, cannot quantize again."
+        scale = tensor_to_scale(self.weight, dtype)
+        quantized_weight = to_fp8_no_autograd(
+            self.weight,
+            scale,
+            dtype,
+            self.forward_config,
+        )
+        self.weight = nn.Parameter(quantized_weight)
+        self.weight.requires_grad = False
+
+    @classmethod
+    def create_meta_class(
+        cls, in_features: int, out_features: int
+    ) -> "Float8LinearInference":
+        with torch.device("meta"):
+            return cls(in_features=in_features, out_features=out_features, bias=False)
+
+    def set_mm_config(self, use_fast_accum: bool = True) -> "Float8LinearInference":
+        """TODO Hardcode for now but we could/should likely add this to the constructor"""
+        self.forward_config: ScaledMMConfig = ScaledMMConfig(False, use_fast_accum)
+        return self
+
+    def set_weight_and_bias(
+        self, weight: torch.nn.Parameter, bias: Optional[torch.nn.Parameter]
+    ) -> "Float8LinearInference":
+        self.weight = weight
+        self.bias = bias
+        return self
+
+    def set_quantization_config(
+        self,
+        quant_config: QuantConfig,
+    ) -> "Float8LinearInference":
+        # We destructure the quant_config into the individual fields
+        # If an activation config is passed in we want to register that as a buffer
+        self.activation_casting: ActivationCasting = quant_config.activation_casting
+        self.quantize_weight()
+
+        if self.activation_casting == ActivationCasting.STATIC:
+            self.register_buffer("activation_scale", quant_config.activation_scale)
+        else:
+            self.activation_scale = None
+        return self
+
+    @classmethod
+    def from_float(
+        cls,
+        module: nn.Module,
+        quant_config: QuantConfig,
+    ) -> "Float8LinearInference":
+        """
+        Create an nn.Linear with fp8 compute from a regular nn.Linear
+
+        Args:
+            mod (torch.nn.Linear): nn.Linear to convert
+            quant_config (QuantConfig): Configuration for the weight and activation casting
+        """
+        return (
+            cls.create_meta_class(module.in_features, module.out_features)
+            .set_weight_and_bias(module.weight, module.bias)
+            .set_mm_config()
+            .set_quantization_config(quant_config)
+        )
+
+
+def cast_to_float8_e4m3fn(
+    inpt_tensor: torch.Tensor,
+    mm_config: ScaledMMConfig,
+    reduce_amax: bool = False,
+    activation_scale: Optional[torch.Tensor] = None,
+) -> Float8Tensor:
+    """Casts an input tensor to the Float8 (e4m3fn) format for efficient computation.
+
+    Args:
+        inpt_tensor: The input tensor to be cast.
+        mm_config: Configuration settings for the matrix multiplication
+        reduce_amax: Whether to reduce the amax (absolute maximum) among the local distributed group.
+        activation_scale: Optional tensor specifying the scale for activation. Default is None.
+
+    Returns:
+        Float8Tensor: The input tensor cast to Float8 (e4m3fn) format.
+
+    Note:
+        If the input tensor is already in Float8 format, it is returned as is without re-casting.
+    """
+    if tensor_already_casted_to_fp8(inpt_tensor):
+        return inpt_tensor
+    scale = (
+        activation_scale
+        if activation_scale is not None
+        else tensor_to_scale(inpt_tensor, e4m3_dtype, reduce_amax)
+    )
+    return Float8Tensor.to_float8(inpt_tensor, scale, e4m3_dtype, mm_config=mm_config)
+
+
+def quantize_to_float8(
+    module: nn.Module,
+    quant_config: QuantConfig,
+    *,
+    skip_fqn_list: Optional[List[str]] = None,
+) -> nn.Module:
+    """
+    Converts torch.nn.Linear layers in the given module to Float8LinearInference.
+
+    Note:
+        If applied to a root-level nn.Linear, the module will not be modified in place
+        and returned instead
+
+    Args:
+        module (nn.Module): The module to modify.
+        quant_config (QuantConfig): Quantization configuration for Float8 conversion.
+        skip_fqn_list (List[str], optional): List of module FQNs to skip during conversion.
+
+    Returns:
+        nn.Module: The modified module with applicable Linear layers converted to Float8.
+
+    Raises:
+        AssertionError: If a root-level nn.Linear with children is encountered.
+    """
+    return swap_linear_layers(
+        module,
+        lambda m: Float8LinearInference.from_float(m, quant_config),
+        skip_fqn_list=skip_fqn_list,
+    )

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -6,6 +6,7 @@
 """
 Defines an nn module designed to be used during inference
 """
+
 from dataclasses import dataclass
 
 from enum import auto, Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.2",
+    "torch >= 2.3",
 ]
 
 [project.optional-dependencies]

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -127,7 +127,7 @@ class TestFloat8Tensor(unittest.TestCase):
         )
         fp8_b.copy_(fp8_a)
         torch.testing.assert_close(fp8_a._data, fp8_b._data)
-    
+
     def test_weights_only_load(self):
         module = nn.Linear(16, 16)
         # Save model state dict

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -135,8 +135,7 @@ class TestFloat8Tensor(unittest.TestCase):
         fp8_module = quantize_to_float8(
             module,
             QuantConfig(
-                ActivationCasting.STATIC,
-                torch.tensor([1.0], device="cuda", dtype=torch.float32),
+                ActivationCasting.DYNAMIC,
             ),
         )
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import io
 import itertools
 import random
 import re
@@ -13,6 +14,7 @@ import pytest
 
 import torch
 import torch.nn as nn
+
 from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_linear_utils import (
@@ -36,6 +38,11 @@ from float8_experimental.float8_utils import (
     fp8_tensor_statistics,
     FP8_TYPES,
     tensor_to_scale,
+)
+from float8_experimental.inference import (
+    ActivationCasting,
+    QuantConfig,
+    quantize_to_float8,
 )
 
 random.seed(0)
@@ -120,6 +127,22 @@ class TestFloat8Tensor(unittest.TestCase):
         )
         fp8_b.copy_(fp8_a)
         torch.testing.assert_close(fp8_a._data, fp8_b._data)
+    
+    def test_weights_only_load(self):
+        module = nn.Linear(16, 16)
+        # Save model state dict
+        buffer = io.BytesIO()
+        fp8_module = quantize_to_float8(
+            module,
+            QuantConfig(
+                ActivationCasting.STATIC,
+                torch.tensor([1.0], device="cuda", dtype=torch.float32),
+            ),
+        )
+
+        torch.save(fp8_module.state_dict(), buffer)
+        buffer.seek(0)
+        _ = torch.load(buffer, weights_only=True)
 
 
 class TestFloat8Linear:

--- a/test/test_everything.sh
+++ b/test/test_everything.sh
@@ -7,6 +7,7 @@ IS_ROCM=$(rocm-smi --version || true)
 pytest test/test_base.py
 pytest test/test_sam.py
 pytest test/test_compile.py
+pytest test/test_inference_flows.py
 
 # These tests do not work on ROCm yet
 if [ -z "$IS_ROCM" ]

--- a/test/test_inference_flows.py
+++ b/test/test_inference_flows.py
@@ -105,7 +105,9 @@ class TestHPTrainToFP8LinearInference:
         static_fp8_mlp = copy.deepcopy(original_mlp)
         quant_config = QuantConfig(
             ActivationCasting.STATIC,
-            activation_scale=torch.tensor([1.0], device="cuda", dtype=torch.float32),
+            static_quantization_scale=torch.tensor(
+                [1.0], device="cuda", dtype=torch.float32
+            ),
         )
         quantize_to_float8(static_fp8_mlp, quant_config)
 

--- a/test/test_inference_flows.py
+++ b/test/test_inference_flows.py
@@ -19,7 +19,7 @@ from float8_experimental.float8_tensor import Float8Tensor
 from float8_experimental.float8_utils import compute_error
 from float8_experimental.inference import (
     ActivationCasting,
-    Float8LinearInference,
+    Float8InferenceLinear,
     QuantConfig,
     quantize_to_float8,
 )
@@ -228,7 +228,7 @@ class TestFP8TrainToFP8LinearInference:
 
         fp8_mod_count = 0
         for module in new_fp8_mlp.modules():
-            if isinstance(module, Float8LinearInference):
+            if isinstance(module, Float8InferenceLinear):
                 assert isinstance(module.weight, Float8Tensor)
                 assert module.weight.requires_grad is False
                 fp8_mod_count += 1

--- a/test/test_inference_flows.py
+++ b/test/test_inference_flows.py
@@ -1,0 +1,244 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import copy
+import io
+import random
+import unittest
+
+import pytest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
+from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
+from float8_experimental.float8_tensor import Float8Tensor
+from float8_experimental.float8_utils import compute_error
+from float8_experimental.inference import (
+    ActivationCasting,
+    Float8LinearInference,
+    QuantConfig,
+    quantize_to_float8,
+)
+
+
+random.seed(0)
+torch.manual_seed(0)
+
+is_H100 = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0)
+
+
+class FeedForward(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(4096, 14336, bias=False)
+        self.w3 = nn.Linear(4096, 14336, bias=False)
+        self.w2 = nn.Linear(14336, 4096, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+    def reset_parameters(self):
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                m.reset_parameters()
+
+
+class TestHPTrainToFP8LinearInference:
+    def base_test_mlp_transform(self, base_mlp, quantized_mlp, input_tensor):
+        with torch.no_grad():
+            base_output = base_mlp(input_tensor)
+            transformed_output = quantized_mlp(input_tensor)
+
+        # Compute and check SQNR
+        sqnr = compute_error(base_output, transformed_output)
+        assert sqnr.item() > 20, f"SQNR is too low: {sqnr.item()} dB"
+
+    @pytest.mark.parametrize("compile_backend", ["eager", "inductor"])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not is_H100,
+        "CUDA not available or on non H100 machine",
+    )
+    def test_dynamic_fp8_mlp(self, compile_backend, dtype):
+        original_mlp = FeedForward().to("cuda", dtype=dtype)
+        original_mlp.reset_parameters()
+
+        dynamic_fp8_mlp = copy.deepcopy(original_mlp)
+
+        quant_config = QuantConfig(ActivationCasting.DYNAMIC)
+        quantize_to_float8(dynamic_fp8_mlp, quant_config)
+
+        batch_size = 4
+        num_tokens = 1024
+        embedding_dim = 4096
+
+        input_tensor = torch.randn(
+            batch_size, num_tokens, embedding_dim, device="cuda", dtype=dtype
+        )
+
+        # Compile the models
+        compiled_original_mlp = torch.compile(
+            original_mlp, backend=compile_backend, fullgraph=True
+        )
+        compiled_dynamic_fp8_mlp = torch.compile(
+            dynamic_fp8_mlp, backend=compile_backend, fullgraph=True
+        )
+
+        self.base_test_mlp_transform(
+            compiled_original_mlp, compiled_dynamic_fp8_mlp, input_tensor
+        )
+
+    @pytest.mark.parametrize("compile_backend", ["eager", "inductor"])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not is_H100,
+        "CUDA not available or on non H100 machine",
+    )
+    def test_static_fp8_mlp(self, compile_backend, dtype):
+        original_mlp = FeedForward().to("cuda", dtype=dtype)
+        original_mlp.reset_parameters()
+
+        static_fp8_mlp = copy.deepcopy(original_mlp)
+        quant_config = QuantConfig(
+            ActivationCasting.STATIC,
+            activation_scale=torch.tensor([1.0], device="cuda", dtype=torch.float32),
+        )
+        quantize_to_float8(static_fp8_mlp, quant_config)
+
+        batch_size = 4
+        num_tokens = 1024
+        embedding_dim = 4096
+
+        input_tensor = torch.randn(
+            batch_size, num_tokens, embedding_dim, device="cuda", dtype=dtype
+        )
+
+        # Compile the models
+        compiled_original_mlp = torch.compile(
+            original_mlp, backend=compile_backend, fullgraph=True
+        )
+        compiled_static_fp8_mlp = torch.compile(
+            static_fp8_mlp, backend=compile_backend, fullgraph=True
+        )
+
+        self.base_test_mlp_transform(
+            compiled_original_mlp, compiled_static_fp8_mlp, input_tensor
+        )
+
+    @pytest.mark.parametrize("compile_backend", ["eager", "inductor"])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not is_H100,
+        "CUDA not available or on non H100 machine",
+    )
+    def test_weight_only_fp8_mlp(self, compile_backend, dtype):
+        original_mlp = FeedForward().to("cuda", dtype=dtype)
+        original_mlp.reset_parameters()
+
+        static_fp8_mlp = copy.deepcopy(original_mlp)
+        quant_config = QuantConfig(ActivationCasting.WEIGHT_ONLY)
+        quantize_to_float8(static_fp8_mlp, quant_config)
+
+        batch_size = 4
+        num_tokens = 1024
+        embedding_dim = 4096
+
+        input_tensor = torch.randn(
+            batch_size, num_tokens, embedding_dim, device="cuda", dtype=dtype
+        )
+
+        # Compile the models
+        compiled_original_mlp = torch.compile(
+            original_mlp, backend=compile_backend, fullgraph=True
+        )
+        compiled_static_fp8_mlp = torch.compile(
+            static_fp8_mlp, backend=compile_backend, fullgraph=True
+        )
+
+        self.base_test_mlp_transform(
+            compiled_original_mlp, compiled_static_fp8_mlp, input_tensor
+        )
+
+
+class TestFP8TrainToFP8LinearInference:
+    def train(self, model: nn.Module, dtype: torch.dtype):
+        model.train()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
+        criterion = nn.MSELoss()
+        target_tensor = torch.randn(4, 1024, 4096, device="cuda", dtype=dtype)
+        for _ in range(10):
+            input_tensor = torch.randn(4, 1024, 4096, device="cuda", dtype=dtype)
+            optimizer.zero_grad()
+            output = model(input_tensor)
+            loss = criterion(output, target_tensor)
+            loss.backward()
+            optimizer.step()
+        model.eval()
+        return model
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not is_H100,
+        "CUDA not available or on non H100 machine",
+    )
+    def test_fp8_save_and_load(self, dtype: torch.dtype):
+        # Initialize FP8 model
+        fp8_mlp = FeedForward().to("cuda", dtype=torch.float32)
+        fp8_mlp.reset_parameters()
+        swap_linear_with_float8_linear(
+            fp8_mlp,
+            Float8DynamicLinear,
+        )
+
+        # Train the model
+        self.train(fp8_mlp, dtype)
+
+        # Generate input tensor and original out
+        input_tensor = torch.randn(4, 1024, 4096, device="cuda", dtype=dtype)
+        og_out = fp8_mlp(input_tensor)
+
+        # Save model state dict
+        buffer = io.BytesIO()
+        torch.save(fp8_mlp.state_dict(), buffer)
+
+        # Reset buffer position to the beginning
+        buffer.seek(0)
+
+        # Later on you load the model, will be w/ Float8DynamicLinear on meta device
+        with torch.device("meta"):
+            new_fp8_mlp = FeedForward().to(dtype=dtype)
+            swap_linear_with_float8_linear(
+                new_fp8_mlp,
+                Float8DynamicLinear,
+            )
+
+        # Load the actual data
+        new_fp8_mlp.load_state_dict(
+            torch.load(buffer, weights_only=True), strict=True, assign=True
+        )
+
+        quant_config = QuantConfig(ActivationCasting.DYNAMIC)
+        quantize_to_float8(new_fp8_mlp, quant_config)
+
+        fp8_mod_count = 0
+        for module in new_fp8_mlp.modules():
+            if isinstance(module, Float8LinearInference):
+                assert isinstance(module.weight, Float8Tensor)
+                assert module.weight.requires_grad is False
+                fp8_mod_count += 1
+        assert fp8_mod_count == 3, "Expected 3 FP8 modules, got {}".format(
+            fp8_mod_count
+        )
+
+        new_out = new_fp8_mlp(input_tensor)
+
+        # Assert exact equality
+        assert torch.all(og_out == new_out).item()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
# Summary
# Perf script:
https://gist.github.com/drisspg/f7a553710d64cce013227a2249d582d2

## Performance

In eager this produces:

| Operation                         | Time (μs)  |
|-----------------------------------|------------|
| bf16                              | 2667.9172  |
| fp8_dynamic_activations           | 2494.7294  |
| fp8_static_activations            | 2449.1784  |
| fp8_weight_only_activations       | 4084.7190  |


With compile this produces:
| Operation                    | Time (μs)  |
|------------------------------|------------|
| bf16                         | 2547.1938  |
| fp8_dynamic_activations      | 1542.0729  |
| fp8_static_activations       | 1407.0310  |
| fp8_weight_only_activations  | 2750.6369  |


## UX

#### Dynamic activation quantization
``` Python

original_mlp = FeedForward().to("cuda", dtype=dtype)
original_mlp.reset_parameters()

dynamic_fp8_mlp = copy.deepcopy(original_mlp)

quant_config = QuantConfig(ActivationCasting.DYNAMIC)
quantize_to_float8(dynamic_fp8_mlp, quant_config)
```

#### Static activation quantization
```Python
original_mlp = FeedForward().to("cuda", dtype=dtype)
original_mlp.reset_parameters()

static_fp8_mlp = copy.deepcopy(original_mlp)
quant_config = QuantConfig(
    ActivationCasting.STATIC,
    static_quantization_scale=torch.tensor(
        [1.0], device="cuda", dtype=torch.float32
    ),
)
quantize_to_float8(static_fp8_mlp, quant_config)
```

#### Weight Only quantization
``` Python
  original_mlp = FeedForward().to("cuda", dtype=dtype)
  original_mlp.reset_parameters()

  wo_fp8_mlp = copy.deepcopy(original_mlp)
  quant_config = QuantConfig(ActivationCasting.WEIGHT_ONLY)
  quantize_to_float8(wo_fp8_mlp, quant_config)
```

All of these are using Per-Tensor scaling will add in a follow up PR row-wise scaling and likely make this the default.