### PR TITLE
[1/x]: Make Float8Linear support dynamic scaling

### DIFF
--- a/.github/workflows/ufmt.yml
+++ b/.github/workflows/ufmt.yml
@@ -21,11 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install black==23.3.0 usort==1.0.6 ufmt==2.1.0 libcst==1.0.1
-    - name: debug
-      run: |
-        ufmt format .
-        git diff
-        git restore .
     - name: Analyzing the code with ufmt
       run: |
         ufmt check .

--- a/.github/workflows/ufmt.yml
+++ b/.github/workflows/ufmt.yml
@@ -21,6 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install black==23.3.0 usort==1.0.6 ufmt==2.1.0 libcst==1.0.1
+    - name: debug
+      run: |
+        ufmt format .
+        git diff
+        git restore .
     - name: Analyzing the code with ufmt
       run: |
         ufmt check .

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -8,12 +8,18 @@ A simple module swap UX for a float8 version of `torch.nn.Linear`.
 """
 
 import dataclasses
+import enum
 
 from typing import Optional
 
 import float8_experimental.config as config
 
 import torch
+
+from float8_experimental.float8_dynamic_linear import (
+    cast_to_float8_e4m3_dynamic,
+    cast_to_float8_e5m2_dynamic_bw,
+)
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
@@ -125,6 +131,18 @@ class DelayedScalingRecipe:
         ), f"{self.scale_fn_name} is not implemented yet. Only max is supported for now."
 
 
+class TensorScalingType(enum.Enum):
+    DELAYED = "delayed"
+    DYNAMIC = "dynamic"
+
+    def short_str(self):
+        if self is TensorScalingType.DELAYED:
+            return "del"
+        else:
+            assert self is TensorScalingType.DYNAMIC
+            return "dyn"
+
+
 class Float8Linear(torch.nn.Linear):
     """
     A wrapper around a `torch.nn.Linear` module which does fp8 compute, and tracks
@@ -132,12 +150,34 @@ class Float8Linear(torch.nn.Linear):
     """
 
     def __init__(self, *args, **kwargs):
+        """
+        Additional arguments on top of `torch.nn.Linear`'s arguments:
+        * `delayed_scaling_recipe`: configuration for delayed scaling
+        * `scaling_type_x`: delayed vs dynamic scaling for `x`
+        * `scaling_type_w`: delayed vs dynamic scaling for `w`
+        * `scaling_type_dL_dY`: delayed vs dynamic scaling for `dL_dY`
+        """
+
         delayed_scaling_recipe = kwargs.pop(
             "delayed_scaling_recipe", DelayedScalingRecipe()
         )
         # Amax scales should always be kept as float32.
         self.always_float32_buffers = set()
+        scaling_type_x = kwargs.pop("scaling_type_x", TensorScalingType.DELAYED)
+        scaling_type_w = kwargs.pop("scaling_type_w", TensorScalingType.DELAYED)
+        scaling_type_dL_dY = kwargs.pop("scaling_type_dL_dY", TensorScalingType.DELAYED)
         super().__init__(*args, **kwargs)
+
+        # Defines the scaling behavior of x, w, dL_dY
+        self.scaling_type_x = scaling_type_x
+        self.scaling_type_w = scaling_type_w
+        self.scaling_type_dL_dY = scaling_type_dL_dY
+        # Convenience flag to skip code related to delayed scaling
+        self.has_any_delayed_scaling = (
+            self.scaling_type_x is TensorScalingType.DELAYED
+            or self.scaling_type_w is TensorScalingType.DELAYED
+            or self.scaling_type_dL_dY is TensorScalingType.DELAYED
+        )
 
         # TODO(future): have a unique recipe per buffer instead of one per
         # module, saving implementing that until we need it.
@@ -175,37 +215,44 @@ class Float8Linear(torch.nn.Linear):
         # Default values for history buffers, see above TODO
         history_len = self.recipe.history_len
         device = self.weight.device
+        # TODO(future PR): dtype values below don't have the other float8
+        # flavors, fix it
         default_x = torch.finfo(torch.float8_e4m3fn).max
         default_w = torch.finfo(torch.float8_e4m3fn).max
         default_dl_dy = torch.finfo(torch.float8_e5m2).max
 
-        self.register_always_float32_buffer(
-            "fp8_amax_x", torch.tensor([default_x], device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_amax_history_x", torch.zeros(history_len, device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_scale_x", torch.tensor([1.0], device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_amax_w", torch.tensor([default_w], device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_amax_history_w", torch.zeros(history_len, device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_scale_w", torch.tensor([1.0], device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_amax_dL_dY", torch.tensor([default_dl_dy], device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_amax_history_dL_dY", torch.zeros(history_len, device=device)
-        )
-        self.register_always_float32_buffer(
-            "fp8_scale_dL_dY", torch.tensor([1.0], device=device)
-        )
+        # Note: for now, create all the buffers if any are needed, to postpone
+        # the work to make the scale and amax syncing and history calculation
+        # handle a heterogeneous setup. We can do that work later if benchmarks
+        # show it is worth doing.
+        if self.has_any_delayed_scaling:
+            self.register_always_float32_buffer(
+                "fp8_amax_x", torch.tensor([default_x], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_x", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_x", torch.tensor([1.0], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_w", torch.tensor([default_w], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_w", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_w", torch.tensor([1.0], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_dL_dY", torch.tensor([default_dl_dy], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_dL_dY", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_dL_dY", torch.tensor([1.0], device=device)
+            )
 
     def register_always_float32_buffer(
         self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True
@@ -234,61 +281,77 @@ class Float8Linear(torch.nn.Linear):
             autocast_dtype = torch.get_autocast_gpu_dtype()
             x = x.to(autocast_dtype)
 
-        scale_fn_name = self.recipe.scale_fn_name
-        _maybe_initialize_amaxes_scales_for_float8_cast(
-            x,
-            self.fp8_amax_x,
-            self.fp8_amax_history_x,
-            self.fp8_scale_x,
-            scale_fn_name,
-            e4m3_dtype,
-            is_amax_initialized,
-            reduce_amax=True,
-        )
-        x_fp8 = Float8Tensor.to_float8(
-            x,
-            self.fp8_scale_x,
-            e4m3_dtype,
-            self.fp8_amax_x,
-            self.forward_config,
-        )
+        if self.scaling_type_x is TensorScalingType.DELAYED:
+            scale_fn_name = self.recipe.scale_fn_name
+            _maybe_initialize_amaxes_scales_for_float8_cast(
+                x,
+                self.fp8_amax_x,
+                self.fp8_amax_history_x,
+                self.fp8_scale_x,
+                scale_fn_name,
+                e4m3_dtype,
+                is_amax_initialized,
+                reduce_amax=True,
+            )
+            x_fp8 = Float8Tensor.to_float8(
+                x,
+                self.fp8_scale_x,
+                e4m3_dtype,
+                self.fp8_amax_x,
+                self.forward_config,
+            )
+        else:
+            assert self.scaling_type_x is TensorScalingType.DYNAMIC
+            x_fp8 = cast_to_float8_e4m3_dynamic(x, self.forward_config)
         return x_fp8
 
     def cast_w_to_float8(
         self, w: torch.Tensor, is_amax_initialized: bool
     ) -> torch.Tensor:
-        scale_fn_name = self.recipe.scale_fn_name
-        _maybe_initialize_amaxes_scales_for_float8_cast(
-            w,
-            self.fp8_amax_w,
-            self.fp8_amax_history_w,
-            self.fp8_scale_w,
-            scale_fn_name,
-            e4m3_dtype,
-            is_amax_initialized,
-            reduce_amax=False,
-        )
+        if self.scaling_type_w is TensorScalingType.DELAYED:
+            scale_fn_name = self.recipe.scale_fn_name
+            _maybe_initialize_amaxes_scales_for_float8_cast(
+                w,
+                self.fp8_amax_w,
+                self.fp8_amax_history_w,
+                self.fp8_scale_w,
+                scale_fn_name,
+                e4m3_dtype,
+                is_amax_initialized,
+                reduce_amax=False,
+            )
 
-        w_fp8 = Float8Tensor.to_float8(
-            w,
-            self.fp8_scale_w,
-            e4m3_dtype,
-            self.fp8_amax_w,
-            self.forward_config,
-        )
+            w_fp8 = Float8Tensor.to_float8(
+                w,
+                self.fp8_scale_w,
+                e4m3_dtype,
+                self.fp8_amax_w,
+                self.forward_config,
+            )
+        else:
+            assert self.scaling_type_w is TensorScalingType.DYNAMIC
+            # TODO(future): also support FSDP integration in delayed scaling path
+            if isinstance(self.weight, Float8Tensor):  # cast by FSDP
+                w_fp8 = self.weight
+            else:
+                w_fp8 = cast_to_float8_e4m3_dynamic(self.weight, self.forward_config)
         return w_fp8
 
     def cast_y_to_float8_in_bw(self, y: torch.Tensor) -> torch.Tensor:
-        scale_fn_name = self.recipe.scale_fn_name
-        y = NoopFwToFloat8E5M2Bw.apply(
-            y,
-            self.fp8_amax_dL_dY,
-            self.fp8_amax_history_dL_dY,
-            self.fp8_scale_dL_dY,
-            scale_fn_name,
-            self.is_amax_initialized,
-            self.backward_config,
-        )
+        if self.scaling_type_dL_dY is TensorScalingType.DELAYED:
+            scale_fn_name = self.recipe.scale_fn_name
+            y = NoopFwToFloat8E5M2Bw.apply(
+                y,
+                self.fp8_amax_dL_dY,
+                self.fp8_amax_history_dL_dY,
+                self.fp8_scale_dL_dY,
+                scale_fn_name,
+                self.is_amax_initialized,
+                self.backward_config,
+            )
+        else:
+            assert self.scaling_type_dL_dY is TensorScalingType.DYNAMIC
+            y = cast_to_float8_e5m2_dynamic_bw(y, self.backward_config)
         return y
 
     def float8_pre_forward(self, x):
@@ -313,7 +376,8 @@ class Float8Linear(torch.nn.Linear):
         self.amax_and_scale_synced = False
 
     def forward(self, x):
-        self.float8_pre_forward(x)
+        if self.has_any_delayed_scaling:
+            self.float8_pre_forward(x)
 
         x_fp8 = self.cast_x_to_float8(x, self.is_amax_initialized)
         w_fp8 = self.cast_w_to_float8(self.weight, self.is_amax_initialized)
@@ -326,11 +390,29 @@ class Float8Linear(torch.nn.Linear):
         if self.bias is not None:
             y = y + self.bias.to(y.dtype)
 
-        self.float8_post_forward()
+        if self.has_any_delayed_scaling:
+            self.float8_post_forward()
         return y
 
+    def extra_repr(self):
+        # example: in_features=32, out_features=16, bias=True
+        s = super().extra_repr()
+        # add scaling settings without using too many characters
+        scaling = f"x:{self.scaling_type_x.short_str()},w:{self.scaling_type_w.short_str()},dldy:{self.scaling_type_dL_dY.short_str()}"
+
+        s = f'{s}, scaling="{scaling}"'
+        # example: in_features=32, out_features=16, bias=True, scaling="x:del,w:del,dldy:dyn"
+        return s
+
     @classmethod
-    def from_float(cls, mod, emulate: bool = False):
+    def from_float(
+        cls,
+        mod,
+        emulate: bool = False,
+        scaling_type_x=TensorScalingType.DELAYED,
+        scaling_type_w=TensorScalingType.DELAYED,
+        scaling_type_dL_dY=TensorScalingType.DELAYED,
+    ):
         """
         Create an nn.Linear with fp8 compute from a regular nn.Linear
 
@@ -339,7 +421,14 @@ class Float8Linear(torch.nn.Linear):
             emulate (bool): whether to emulate fp8 matmul logic in float32
         """
         with torch.device("meta"):
-            new_mod = cls(mod.in_features, mod.out_features, bias=False)
+            new_mod = cls(
+                mod.in_features,
+                mod.out_features,
+                bias=False,
+                scaling_type_x=scaling_type_x,
+                scaling_type_w=scaling_type_w,
+                scaling_type_dL_dY=scaling_type_dL_dY,
+            )
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
         # need to create buffers again when moving from meta device to
@@ -347,6 +436,7 @@ class Float8Linear(torch.nn.Linear):
         new_mod.create_buffers()
         # Defines the behavior of the matmul in the forward and backward
         # Forward we use fast_accum, backwards we do not
+        # TODO(future PR): move below to the constructor
         new_mod.forward_config = ScaledMMConfig(
             emulate, True if not emulate else False, False, config.pad_inner_dim
         )

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -12,7 +12,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
-from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 
 from float8_experimental.float8_utils import (
     amax_history_to_scale_stack,
@@ -30,35 +30,52 @@ class LinearType(Enum):
     DYNAMIC = auto()
 
 
-REQUIRES_SYNC = {LinearType.DELAYED}
-
-
 def get_float8_linear(
     linear_type: LinearType,
     linear_ref: torch.nn.Linear,
     emulate: bool = False,
+    scaling_type_x: TensorScalingType = TensorScalingType.DELAYED,
+    scaling_type_w: TensorScalingType = TensorScalingType.DELAYED,
+    scaling_type_dL_dY: TensorScalingType = TensorScalingType.DELAYED,
 ):
     """Returns a Float8Linear module of the given type, initialized from linear_ref.
     Args:
         linear_type: The type of Float8Linear to return.
         linear_ref: The linear module to initialize from.
         emulate: Whether to emulate the fp8 matmul logic in float32.
+        scaling_type_x: delayed vs dynamic scaling for `x`.
+        scaling_type_w: delayed vs dynamic scaling for `w`.
+        scaling_type_dL_dY: delayed vs dynamic scaling for `dL_dY`.
     """
-    LINEAR_TYPE_MAP = {
-        LinearType.DELAYED: Float8Linear,
-        LinearType.DYNAMIC: Float8DynamicLinear,
-    }
-    if linear_type not in LINEAR_TYPE_MAP:
-        raise ValueError(f"linear_type must be one of {LINEAR_TYPE_MAP.keys()}")
-    return LINEAR_TYPE_MAP[linear_type].from_float(
-        copy.deepcopy(linear_ref),
-        emulate=emulate,
-    )
+    if linear_type is LinearType.DYNAMIC:
+        return Float8DynamicLinear.from_float(
+            copy.deepcopy(linear_ref), emulate=emulate
+        )
+    else:
+        assert linear_type is LinearType.DELAYED
+        return Float8Linear.from_float(
+            copy.deepcopy(linear_ref),
+            emulate=emulate,
+            scaling_type_x=scaling_type_x,
+            scaling_type_w=scaling_type_w,
+            scaling_type_dL_dY=scaling_type_dL_dY,
+        )
 
 
-def linear_requires_sync(linear_type: LinearType):
+def linear_requires_sync(
+    linear_type: LinearType,
+    scaling_type_x: TensorScalingType = TensorScalingType.DELAYED,
+    scaling_type_w: TensorScalingType = TensorScalingType.DELAYED,
+    scaling_type_dL_dY: TensorScalingType = TensorScalingType.DELAYED,
+):
     """Returns whether the given linear_type requires sync before forward."""
-    return linear_type in REQUIRES_SYNC
+    return linear_type is LinearType.DELAYED and any(
+        [
+            scaling_type_x is TensorScalingType.DELAYED,
+            scaling_type_w is TensorScalingType.DELAYED,
+            scaling_type_dL_dY is TensorScalingType.DELAYED,
+        ]
+    )
 
 
 def _update_history_stack(

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -165,7 +165,6 @@ class TestFloat8Linear:
         if linear_requires_sync(
             linear_type, scaling_type_x, scaling_type_w, scaling_type_dL_dY
         ):
-
             # only check buffers that are actually used, based on per-tensor
             # scaling settings
             amax_buffer_names = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #300
* #299
* #298
* #297
* #296
* #294
* #293
* #291
* __->__ #290

Summary:

At a high level, we need to make dynamic vs delayed scaling configurable
separately for activations, weights and gradients. The way I am
approaching this is as follows:
* PR 1 (this PR): add basic support for dynamic scaling, configurable by tensor, to `Float8Linear`
* PRs 2..n: one by one, add features implemented in `Float8DynamicLinear` to `Float8Linear`, as necessary
* last PR: delete `Float8DynamicLinear`

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59305792](https://our.internmc.facebook.com/intern/diff/D59305792)