### PR TITLE
[3/x]: simplify FSDP1 test and add coverage for dynamic scaling

### DIFF
--- a/test/test_fsdp.sh
+++ b/test/test_fsdp.sh
@@ -4,27 +4,12 @@
 set -e
 
 launch() {
-    echo "launching IS_FP8 $IS_FP8, compile_fsdp $COMPILE, fullgraph $FULLGRAPH"
+    echo "launching compile_fsdp $COMPILE, use_weight_dynamic_scaling $USE_WEIGHT_DYNAMIC_SCALING"
 
-    # generate the test data
-    python test/test_fsdp.py --mode generate --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
-    echo "Success: ✅"
-
-    # generate single GPU model output and updated state dict
-    python test/test_fsdp.py --mode single_gpu --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
-    echo "Success: ✅"
-
-    # generate FSDP model output and updated state dict
     # the NCCL_DEBUG setting is to avoid log spew
     # the CUDA_VISIBLE_DEVICES setting is for easy debugging
-    # the NCCL_NET setting is to work around transient issues on a
-    #   specific host (`devgpu001.nha2`)
-    NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 NCCL_NET=SOCKET python test/test_fsdp.py \
-        --mode fsdp --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
-
-    # compare the outputs and state dicts and verify equivalence
-    python test/test_fsdp.py --mode analyze --is_fp8 $IS_FP8 --compile_fsdp $COMPILE --fullgraph $FULLGRAPH
-    echo "Success: ✅"
+    NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/test_fsdp.py \
+        --compile_fsdp $COMPILE --use_weight_dynamic_scaling $USE_WEIGHT_DYNAMIC_SCALING
 
     echo "✅ All Tests Passed ✅"
 }
@@ -34,10 +19,10 @@ if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; 
     exit
 fi
 
-# IS_FP8, COMPILE, FULLGRAPH
-for i in False,False,False True,False,False True,True,False
+# COMPILE, USE_WEIGHT_DYNAMIC_SCALING
+for i in False,False False,True True,False True,True
 do
     IFS=","; set -- $i;
-    IS_FP8=$1; COMPILE=$2; FULLGRAPH=$3
+    COMPILE=$1; USE_WEIGHT_DYNAMIC_SCALING=$2
     launch
 done


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #300
* #299
* #298
* #297
* #296
* #294
* __->__ #293
* #291
* #290

Summary:

1. simplify the FSDP test, instead of testing 1 GPU vs N GPUs, instead
   hold the number of GPUs constant and test bf16 vs float8. Remove
   various technical debt that accumulated in this test.
2. add testing for dynamic scaling of weights

Test Plan:

```
./test/test_fsdp.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59305791](https://our.internmc.facebook.com/intern/diff/D59305791)