### PR TITLE
[5/x] make FSDP2 with float8 all-gather work for Float8Linear

### DIFF
--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -79,20 +79,6 @@ class TestFloat8Common:
     def swap_linear_with_dynamic(
         self, module: nn.Module, use_float8_linear=False, **kwargs: Any
     ) -> nn.Module:
-        skip_fqn_list = [
-            "output",
-        ]
-        for layer in range(3):
-            skip_fqn_list.append(f"layers.{layer}.attention.wq")
-            skip_fqn_list.append(f"layers.{layer}.attention.wk")
-            skip_fqn_list.append(f"layers.{layer}.attention.wv")
-            skip_fqn_list.append(f"layers.{layer}.attention.wo")
-            skip_fqn_list.append(f"layers.{layer}.feed_forward.w1")
-            # if layer > 0:
-            # skip_fqn_list.append(f"layers.{layer}.feed_forward.w2")
-            # Note: with 3 layers, even a single linear leads to divergence
-            # with 1 layer, reproes for any layer
-        # kwargs["skip_fqn_list"] = skip_fqn_list
         if use_float8_linear:
             kwargs["scaling_type_x"] = TensorScalingType.DYNAMIC
             kwargs["scaling_type_w"] = TensorScalingType.DYNAMIC


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #300
* #299
* #298
* #297
* __->__ #296
* #294
* #293
* #291
* #290

Summary:

Adds test coverage for `Float8Linear` with all dynamic scaling and FSDP2
with float8 all-gather.

To make the tests pass, fixes a bug with initilization ordering in
`Float8Linear.from_float`, we need to have the right forward config
set before stashing it on the weight wrapper.

Test Plan:

```
python test/test_fsdp2/test_fsdp2_eager.py
/test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59305793](https://our.internmc.facebook.com/intern/diff/D59305793)