### PR TITLE
[8/x] make single linear profiling script work with Float8 scaling type

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -400,14 +400,13 @@ class Float8Linear(torch.nn.Linear):
             self.float8_post_forward()
         return y
 
-    def extra_repr(self):
-        # example: in_features=32, out_features=16, bias=True
-        s = super().extra_repr()
+    def scaling_repr(self):
         # add scaling settings without using too many characters
-        scaling = f"x:{self.scaling_type_x.short_str()},w:{self.scaling_type_w.short_str()},dldy:{self.scaling_type_dL_dY.short_str()}"
+        # example: "x:del,w:del,dldy:dyn"
+        return f"x:{self.scaling_type_x.short_str()},w:{self.scaling_type_w.short_str()},dldy:{self.scaling_type_dL_dY.short_str()}"
 
-        s = f'{s}, scaling="{scaling}"'
-        # example: in_features=32, out_features=16, bias=True, scaling="x:del,w:del,dldy:dyn"
+    def extra_repr(self):
+        s = f'{super().extra_repr()}, scaling="{self.scaling_repr()}"'
         return s
 
     @classmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #300
* __->__ #299
* #298
* #297
* #296
* #294
* #293
* #291
* #290

Summary:

Makes `benchmarks/bench_linear_float8.py` support per-tensor scaling
configurations.

Verified that performance is as we expect

Test Plan:

paste of testing for delayed -> dynamic, changing the tensors one by
one:
https://gist.github.com/vkuzo/9e8f995e51ef16f483347c0f86bb0ac3

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59305789](https://our.internmc.facebook.com/intern/diff/D59305789)