### PR TITLE
delete Float8DynamicLinear

### DIFF
--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
 import torch.utils.benchmark as benchmark
-from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 from float8_experimental.float8_linear_utils import (
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
@@ -65,7 +65,13 @@ def get_model(K, N, is_fp8, base_dtype=torch.float32):
         modules.append(nn.ReLU())
     m = nn.Sequential(*modules)
     if is_fp8:
-        swap_linear_with_float8_linear(m, Float8Linear, emulate=False)
+        swap_linear_with_float8_linear(
+            m,
+            emulate=False,
+            scaling_type_x=TensorScalingType.DELAYED,
+            scaling_type_w=TensorScalingType.DELAYED,
+            scaling_type_dL_dY=TensorScalingType.DELAYED,
+        )
     return m
 
 

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -16,7 +16,7 @@ import float8_experimental.config as config
 
 import torch
 
-from float8_experimental.float8_dynamic_linear import (
+from float8_experimental.float8_dynamic_utils import (
     cast_to_float8_e4m3_dynamic,
     cast_to_float8_e5m2_dynamic_bw,
     WeightWithDynamicFloat8CastTensor,
@@ -402,8 +402,8 @@ class Float8Linear(torch.nn.Linear):
 
     def scaling_repr(self):
         # add scaling settings without using too many characters
-        # example: "x:del,w:del,dldy:dyn"
-        return f"x:{self.scaling_type_x.short_str()},w:{self.scaling_type_w.short_str()},dldy:{self.scaling_type_dL_dY.short_str()}"
+        # example: "x_del_w_del_dldy_dyn"
+        return f"x_{self.scaling_type_x.short_str()}_w_{self.scaling_type_w.short_str()}_dldy_{self.scaling_type_dL_dY.short_str()}"
 
     def extra_repr(self):
         s = f'{super().extra_repr()}, scaling="{self.scaling_repr()}"'

--- a/float8_experimental/float8_tensor_parallel.py
+++ b/float8_experimental/float8_tensor_parallel.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from float8_experimental.float8_dynamic_linear import (
+from float8_experimental.float8_dynamic_utils import (
     cast_to_float8_e4m3_dynamic,
     cast_to_float8_e5m2_dynamic_bw,
 )
@@ -21,7 +21,6 @@ from torch.distributed.tensor.parallel import (
 # creating the DTensor.
 
 # NOTE: This only works and tested with the dynamic scaling
-# (Float8DynamicLinear and Float8Linear with dynamic scaling for all tensors)
 
 
 def _float8_linear_supports_float8_allgather(m):
@@ -71,12 +70,11 @@ class Float8ColwiseParallel(ColwiseParallel):
         return outputs.to_local() if use_local_output else outputs
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
         from float8_experimental.float8_linear import Float8Linear
 
-        if not isinstance(module, (Float8DynamicLinear, Float8Linear)):
+        if not isinstance(module, Float8Linear):
             raise ValueError(
-                f"Expecting module to be Float8DynamicLinear or Float8Linear but found {type(module)}"
+                f"Expecting module to be Float8Linear but found {type(module)}"
             )
         elif isinstance(
             module, Float8Linear
@@ -122,12 +120,11 @@ class Float8RowwiseParallel(RowwiseParallel):
         return outputs.to_local() if use_local_output else outputs
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
         from float8_experimental.float8_linear import Float8Linear
 
-        if not isinstance(module, (Float8DynamicLinear, Float8Linear)):
+        if not isinstance(module, Float8Linear):
             raise ValueError(
-                f"Expecting module to be Float8DynamicLinear or Float8Linear but found {type(module)}"
+                f"Expecting module to be Float8Linear but found {type(module)}"
             )
         elif isinstance(
             module, Float8Linear
@@ -147,7 +144,7 @@ class PrepareFloat8ModuleInput(PrepareModuleInput):
     #   float8_dtype (torch.dtype, optional): control what float8 dtype to cast to when prepare the module input,
     #       we currently only support torch.float8_e4m3fn. default: torch.float8_e4m3fn
     #   fwd_config_submodule_fqn (str, optional): the fqn of the submodule that contains the forward config used
-    #       for the float8 cast. If not specified, we will search for the Float8DynamicLinear in the submodules
+    #       for the float8 cast. If not specified, we will search for the Float8Linear in the submodules
     #       and use the forward config from that module, in this case all module's forward config must be
     #       the same.
 
@@ -204,24 +201,23 @@ class PrepareFloat8ModuleInput(PrepareModuleInput):
             return input
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
         from float8_experimental.float8_linear import Float8Linear
 
         fwd_linear_config = None
         if self.fwd_config_submodule_fqn is not None:
             fwd_linear = module.get_submodule(self.fwd_config_submodule_fqn)
-            assert isinstance(fwd_linear, (Float8DynamicLinear, Float8Linear))
+            assert isinstance(fwd_linear, Float8Linear)
             fwd_linear_config = fwd_linear.forward_config
         else:
             # search for ScaledMM configs for all the submodules and make sure they are the same
             for mod in module.modules():
-                if isinstance(mod, (Float8DynamicLinear, Float8Linear)):
+                if isinstance(mod, Float8Linear):
                     if fwd_linear_config is None:
                         fwd_linear_config = mod.forward_config
                     else:
                         assert (
                             fwd_linear_config == mod.forward_config
-                        ), "All the Float8DynamicLinear and Float8Linear modules should have same forward config!"
+                        ), "All the Float8Linear modules should have same forward config!"
 
         self.fwd_linear_config = fwd_linear_config
         super()._apply(module, device_mesh)

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -14,10 +14,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from float8_experimental.float8_dynamic_linear import (
-    Float8DynamicLinear,
-    NoopFwToFloat8E5M2Bw,
-)
+from float8_experimental.float8_dynamic_utils import NoopFwToFloat8E5M2Bw
 from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
@@ -171,37 +168,28 @@ def test_dtensor_fp8_autograd(mesh: DeviceMesh, size=16):
 
 
 def _test_fp8_mlp_tensor_parallelism_base(
-    mesh: DeviceMesh, size=16, compile: bool = False, use_float8_linear: bool = False
+    mesh: DeviceMesh, size=16, compile: bool = False
 ):
     device = mesh.device_type
-    # TODO(future): delete Float8DynamicLinear from this test once all the
-    # code is unified
-    float8_cls = Float8Linear if use_float8_linear else Float8DynamicLinear
-    extra_kwargs = {}
-    if use_float8_linear:
-        # For now, just use Float8Linear with dynamic scaling, which is the
-        # same behavior as Float8Linear.
-        # TODO(future): add support for float8 all-gather with delayed scaling
-        # for activations and gradients.
-        extra_kwargs = {
-            "scaling_type_x": TensorScalingType.DYNAMIC,
-            "scaling_type_w": TensorScalingType.DYNAMIC,
-            "scaling_type_dL_dY": TensorScalingType.DYNAMIC,
-        }
+    # For now, just use Float8Linear with dynamic scaling, which is the
+    # same behavior as Float8Linear.
+    # TODO(future): add support for float8 all-gather with delayed scaling
+    # for activations and gradients.
+    extra_kwargs = {
+        "scaling_type_x": TensorScalingType.DYNAMIC,
+        "scaling_type_w": TensorScalingType.DYNAMIC,
+        "scaling_type_dL_dY": TensorScalingType.DYNAMIC,
+    }
 
     toy_model = ToyModel().to(device)
     toy_model_fp8 = swap_linear_with_float8_linear(
-        toy_model, float8_cls, emulate=True, **extra_kwargs
+        toy_model, emulate=True, **extra_kwargs
     )
 
     tp_model = copy.deepcopy(toy_model)
-    tp_model = swap_linear_with_float8_linear(
-        tp_model, float8_cls, emulate=True, **extra_kwargs
-    )
+    tp_model = swap_linear_with_float8_linear(tp_model, emulate=True, **extra_kwargs)
     sp_model = copy.deepcopy(toy_model)
-    sp_model = swap_linear_with_float8_linear(
-        sp_model, float8_cls, emulate=True, **extra_kwargs
-    )
+    sp_model = swap_linear_with_float8_linear(sp_model, emulate=True, **extra_kwargs)
 
     # vanilla TP
     tp_model = parallelize_module(
@@ -232,9 +220,7 @@ def _test_fp8_mlp_tensor_parallelism_base(
 
     # PrepareFloat8ModuleInput with specific submodule fqn
     sp_model2 = copy.deepcopy(toy_model)
-    sp_model2 = swap_linear_with_float8_linear(
-        sp_model2, Float8DynamicLinear, emulate=True, **extra_kwargs
-    )
+    sp_model2 = swap_linear_with_float8_linear(sp_model2, emulate=True, **extra_kwargs)
 
     sp_model2 = parallelize_module(
         sp_model2,
@@ -287,27 +273,11 @@ def _test_fp8_mlp_tensor_parallelism_base(
 
 
 def test_fp8_mlp_tensor_parallelism_eager(mesh: DeviceMesh, size=16):
-    _test_fp8_mlp_tensor_parallelism_base(
-        mesh, size, compile=False, use_float8_linear=False
-    )
-
-
-def test_fp8_mlp_tensor_parallelism_eager_float8_linear(mesh: DeviceMesh, size=16):
-    _test_fp8_mlp_tensor_parallelism_base(
-        mesh, size, compile=False, use_float8_linear=True
-    )
+    _test_fp8_mlp_tensor_parallelism_base(mesh, size, compile=False)
 
 
 def test_fp8_mlp_tensor_parallelism_compile(mesh: DeviceMesh, size=16):
-    _test_fp8_mlp_tensor_parallelism_base(
-        mesh, size, compile=True, use_float8_linear=False
-    )
-
-
-def test_fp8_mlp_tensor_parallelism_compile_float8_linear(mesh: DeviceMesh, size=16):
-    _test_fp8_mlp_tensor_parallelism_base(
-        mesh, size, compile=True, use_float8_linear=True
-    )
+    _test_fp8_mlp_tensor_parallelism_base(mesh, size, compile=True)
 
 
 if __name__ == "__main__":
@@ -321,9 +291,7 @@ if __name__ == "__main__":
         test_dtensor_cast_to_fp8,
         test_dtensor_fp8_autograd,
         test_fp8_mlp_tensor_parallelism_eager,
-        test_fp8_mlp_tensor_parallelism_eager_float8_linear,
         test_fp8_mlp_tensor_parallelism_compile,
-        test_fp8_mlp_tensor_parallelism_compile_float8_linear,
     ]
 
     for test in tqdm(tests, desc="Running tests"):

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -24,7 +24,6 @@ import torch.nn as nn
 from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 from float8_experimental.float8_linear_utils import (
     linear_requires_sync,
-    LinearType,
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
 )
@@ -84,7 +83,6 @@ def fsdp_main(rank, world_size, args):
     # with weights.
     swap_linear_with_float8_linear(
         model_fp8,
-        Float8Linear,
         emulate=False,
         scaling_type_w=scaling_type_w,
     )
@@ -133,7 +131,6 @@ def fsdp_main(rank, world_size, args):
         y_local = model(ref_input_local[i])
         y_local.backward(ref_grad_local[i])
         if is_fp8 and linear_requires_sync(
-            LinearType.DELAYED,
             TensorScalingType.DYNAMIC,
             scaling_type_w,
             TensorScalingType.DYNAMIC,

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from float8_experimental.float8_linear import Float8Linear
-from float8_experimental.float8_linear_utils import sync_float8_amax_and_scale_history
 
 
 def check_parity_no_mp(
@@ -17,7 +16,6 @@ def check_parity_no_mp(
     fsdp_model: nn.Module,
     fsdp_optim: torch.optim.Optimizer,
     local_inp: torch.Tensor,
-    module_cls: Type,
 ):
     for iter_idx in range(10):
         losses: List[torch.Tensor] = []
@@ -29,8 +27,7 @@ def check_parity_no_mp(
                 for param in model.parameters():
                     dist.all_reduce(param.grad)
                     param.grad.div_(dist.get_world_size())
-            if module_cls is Float8Linear:
-                sync_float8_amax_and_scale_history(model)
+            # TODO(future): add amax syncing once delayed scaling is supported
             optim.step()
         test_cls.assertEqual(losses[0], losses[1])
 
@@ -43,7 +40,6 @@ def check_parity_bf16_mp(
     fsdp_model: nn.Module,
     fsdp_optim: torch.optim.Optimizer,
     local_inp: torch.Tensor,
-    module_cls: Type,
 ):
     for iter_idx in range(10):
         losses: List[torch.Tensor] = []
@@ -62,8 +58,7 @@ def check_parity_bf16_mp(
                     param_bf16.grad.div_(dist.get_world_size())
                     param_fp32.grad = param_bf16.grad.float()
                     param_bf16.grad = None
-            if module_cls is Float8Linear:
-                sync_float8_amax_and_scale_history(model)
+            # TODO(future): add amax syncing once delayed scaling is supported
             optim.step()
             for param_fp32, param_bf16 in zip(
                 ref_model.parameters(), ref_model_bf16.parameters()

--- a/test/test_fsdp2/test_fsdp2_eager.py
+++ b/test/test_fsdp2/test_fsdp2_eager.py
@@ -8,10 +8,7 @@ import torch
 import torch._dynamo.testing
 import torch.distributed as dist
 import torch.nn as nn
-from float8_experimental.float8_dynamic_linear import (
-    Float8DynamicLinear,
-    WeightWithDynamicFloat8CastTensor,
-)
+from float8_experimental.float8_dynamic_utils import WeightWithDynamicFloat8CastTensor
 from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from test_fsdp2_common import (
@@ -76,16 +73,11 @@ class TestFloat8Common:
         dist.broadcast(global_inp, src=0)
         return global_inp.view(self.world_size, -1)[self.rank].view(16, 16)
 
-    def swap_linear_with_dynamic(
-        self, module: nn.Module, use_float8_linear=False, **kwargs: Any
-    ) -> nn.Module:
-        if use_float8_linear:
-            kwargs["scaling_type_x"] = TensorScalingType.DYNAMIC
-            kwargs["scaling_type_w"] = TensorScalingType.DYNAMIC
-            kwargs["scaling_type_dL_dY"] = TensorScalingType.DYNAMIC
-            return swap_linear_with_float8_linear(module, Float8Linear, **kwargs)
-        else:
-            return swap_linear_with_float8_linear(module, Float8DynamicLinear, **kwargs)
+    def swap_linear_with_dynamic(self, module: nn.Module, **kwargs: Any) -> nn.Module:
+        kwargs["scaling_type_x"] = TensorScalingType.DYNAMIC
+        kwargs["scaling_type_w"] = TensorScalingType.DYNAMIC
+        kwargs["scaling_type_dL_dY"] = TensorScalingType.DYNAMIC
+        return swap_linear_with_float8_linear(module, **kwargs)
 
 
 class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
@@ -95,16 +87,10 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
 
     @skip_if_lt_x_gpu(2)
     def test_transformer_parity_dynamic(self):
-        for enable_fsdp_fp8_all_gather, use_float8_linear in itertools.product(
-            [False, True], [False, True]
-        ):
-            self._test_transformer_parity_dynamic(
-                enable_fsdp_fp8_all_gather, use_float8_linear
-            )
+        for enable_fsdp_fp8_all_gather in [False, True]:
+            self._test_transformer_parity_dynamic(enable_fsdp_fp8_all_gather)
 
-    def _test_transformer_parity_dynamic(
-        self, enable_fsdp_fp8_all_gather: bool, use_float8_linear: bool
-    ):
+    def _test_transformer_parity_dynamic(self, enable_fsdp_fp8_all_gather: bool):
         # NOTE: Weight-tying does not compose with fp8 all-gather because the
         # embedding weight and output linear weight are tied but only the
         # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
@@ -112,9 +98,9 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         weight_tying = not enable_fsdp_fp8_all_gather
         module = self.init_transformer(weight_tying=weight_tying)
         ref_module = copy.deepcopy(module)
-        ref_module = self.swap_linear_with_dynamic(ref_module, use_float8_linear).cuda()
+        ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
         with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
-            module = self.swap_linear_with_dynamic(module, use_float8_linear)
+            module = self.swap_linear_with_dynamic(module)
         for submodule in module.modules():
             if isinstance(submodule, TransformerBlock):
                 fully_shard(submodule)
@@ -124,24 +110,15 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         local_inp = torch.randint(
             0, ref_module.tok_embeddings.weight.size(0), (16, 16), device="cuda"
         )
-        # TODO(future): change Float8DynamicLinear to module_cls below, and
-        # ensure there is no amax syncing for all-dynamic
-        check_parity_no_mp(
-            self, ref_module, ref_optim, module, optim, local_inp, Float8DynamicLinear
-        )
+        check_parity_no_mp(self, ref_module, ref_optim, module, optim, local_inp)
 
     @skip_if_lt_x_gpu(2)
     def test_transformer_memory(self):
         """Tests peak active memory in the forward and backward passes."""
-        # for enable_fsdp_fp8_all_gather in [False, True]:
-        for enable_fsdp_fp8_all_gather, use_float8_linear in itertools.product(
-            [False, True], [False, True]
-        ):
-            self._test_transformer_memory(enable_fsdp_fp8_all_gather, use_float8_linear)
+        for enable_fsdp_fp8_all_gather in [False, True]:
+            self._test_transformer_memory(enable_fsdp_fp8_all_gather)
 
-    def _test_transformer_memory(
-        self, enable_fsdp_fp8_all_gather: bool, use_float8_linear: bool
-    ):
+    def _test_transformer_memory(self, enable_fsdp_fp8_all_gather: bool):
         torch.manual_seed(42)
         # Pre-run a linear forward (gemm and bias) and backward (gemm) to
         # allocate the cuBLAS workspaces before measuring the memory usage
@@ -164,9 +141,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         # Emulate the fp8 matmul to bypass the scaled matmul op's divisibility
         # requirement to use a smaller activation size
         with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
-            model = self.swap_linear_with_dynamic(
-                model, emulate=True, use_float8_linear=use_float8_linear
-            )
+            model = self.swap_linear_with_dynamic(model, emulate=True)
         model_unsharded_numel = sum(p.numel() for p in model.parameters())
         model_sharded_numel = (model_unsharded_numel + 1) // 2
         block_lin_weight_numel = 0
@@ -267,21 +242,19 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
     def world_size(self) -> int:
         return 2
 
-    def _test_weight_subclass_dynamic(self, use_float8_linear):
-        float8_cls = Float8Linear if use_float8_linear else Float8DynamicLinear
-        extra_kwargs = {}
-        if use_float8_linear:
-            extra_kwargs["scaling_type_x"] = TensorScalingType.DYNAMIC
-            extra_kwargs["scaling_type_w"] = TensorScalingType.DYNAMIC
-            extra_kwargs["scaling_type_dL_dY"] = TensorScalingType.DYNAMIC
-            pass
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_weight_subclass_dynamic(self):
+        extra_kwargs = {
+            "scaling_type_x": TensorScalingType.DYNAMIC,
+            "scaling_type_w": TensorScalingType.DYNAMIC,
+            "scaling_type_dL_dY": TensorScalingType.DYNAMIC,
+        }
         tensor_cls = WeightWithDynamicFloat8CastTensor
         # Check for a single FSDP paramter group
         module_fp32 = self.init_single_module()
         with set_enable_fsdp_fp8_all_gather(True):
             module = swap_linear_with_float8_linear(
                 module_fp32,
-                float8_cls,
                 emulate=True,
                 **extra_kwargs,
             )
@@ -297,7 +270,6 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         with set_enable_fsdp_fp8_all_gather(True):
             module = swap_linear_with_float8_linear(
                 module,
-                float8_cls,
                 emulate=True,
                 **extra_kwargs,
             )
@@ -313,14 +285,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
                 self.assertIsInstance(param.to_local(), tensor_cls)
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
-    def test_weight_subclass_float8_dynamic_linear(self):
-        self._test_weight_subclass_dynamic(use_float8_linear=False)
-
-    @unittest.skipIf(not TEST_CUDA, "no cuda")
-    def test_weight_subclass_float8_linear(self):
-        self._test_weight_subclass_dynamic(use_float8_linear=True)
-
-    def _test_fp8_fp32_all_gather_dynamic_comm_size(self, use_float8_linear):
+    def test_fp8_fp32_all_gather_dynamic_comm_size(self):
         """
         Tests that fp8 all-gather with dynamic scaling communicates the
         expected number of bytes.
@@ -354,7 +319,7 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         module_fp32 = self.init_single_module()
         ref_module = copy.deepcopy(module_fp32)
         with set_enable_fsdp_fp8_all_gather(True):
-            module = self.swap_linear_with_dynamic(module_fp32, use_float8_linear)
+            module = self.swap_linear_with_dynamic(module_fp32)
         fully_shard(module)
         local_inp = self.get_local_inp()
         expected_all_gather_size = get_expected_all_gather_size(ref_module)
@@ -399,29 +364,17 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             )
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
-    def test_fp8_fp32_all_gather_float8_dynamic_linear_comm_size(self):
-        self._test_fp8_fp32_all_gather_dynamic_comm_size(use_float8_linear=False)
-
-    @unittest.skipIf(not TEST_CUDA, "no cuda")
-    def test_fp8_fp32_all_gather_float8_linear_comm_size(self):
-        self._test_fp8_fp32_all_gather_dynamic_comm_size(use_float8_linear=True)
-
-    @unittest.skipIf(not TEST_CUDA, "no cuda")
     def test_fp32_fp8_single_module_parity(self):
         """
         Tests numeric parity for fp32 parameters with fp8 computation with a
         single module/FSDP communication group.
         """
-        for enable_fsdp_fp8_all_gather, use_float8_linear in itertools.product(
-            [False, True], [False, True]
-        ):
+        for enable_fsdp_fp8_all_gather in [False, True]:
             module_fp32 = self.init_single_module()
-            ref_module = self.swap_linear_with_dynamic(
-                copy.deepcopy(module_fp32), use_float8_linear
-            )
+            ref_module = self.swap_linear_with_dynamic(copy.deepcopy(module_fp32))
             ref_module = ref_module.cuda()
             with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
-                module = self.swap_linear_with_dynamic(module_fp32, use_float8_linear)
+                module = self.swap_linear_with_dynamic(module_fp32)
             fully_shard(module)
             ref_optim = torch.optim.Adam(ref_module.parameters(), lr=1e-2)
             optim = torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True)
@@ -433,7 +386,6 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
                 module,
                 optim,
                 local_inp,
-                Float8DynamicLinear,
             )
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
@@ -442,16 +394,12 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         Tests numeric parity for fp32 parameters with fp8 computation with
         multiple modules/FSDP communication groups.
         """
-        for enable_fsdp_fp8_all_gather, use_float8_linear in itertools.product(
-            [False, True], [False, True]
-        ):
+        for enable_fsdp_fp8_all_gather in [False, True]:
             module = self.init_multi_module()
             ref_module = copy.deepcopy(module)
-            ref_module = self.swap_linear_with_dynamic(
-                ref_module, use_float8_linear
-            ).cuda()
+            ref_module = self.swap_linear_with_dynamic(ref_module).cuda()
             with set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather):
-                module = self.swap_linear_with_dynamic(module, use_float8_linear)
+                module = self.swap_linear_with_dynamic(module)
             for submodule in module:
                 fully_shard(submodule)
             fully_shard(module)
@@ -465,7 +413,6 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
                 module,
                 optim,
                 local_inp,
-                Float8DynamicLinear,
             )
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
@@ -482,13 +429,10 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         ref_module_bf16 = copy.deepcopy(module).to(torch.bfloat16)
         ref_module_bf16 = swap_linear_with_float8_linear(
             ref_module_bf16,
-            Float8DynamicLinear,
             emulate=True,
         )
         ref_module_fp32 = copy.deepcopy(module).cuda()
-        module = swap_linear_with_float8_linear(
-            module, Float8DynamicLinear, emulate=True
-        )
+        module = swap_linear_with_float8_linear(module, emulate=True)
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
         for mlp in module:
             fully_shard(mlp, mp_policy=mp_policy)
@@ -501,7 +445,6 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
             module,
             torch.optim.Adam(module.parameters(), lr=1e-2, foreach=True),
             self.get_local_inp(torch.bfloat16),
-            Float8DynamicLinear,
         )
 
 

--- a/test/test_fsdp_compile.py
+++ b/test/test_fsdp_compile.py
@@ -51,7 +51,6 @@ def get_model(K, N, is_fp8, emulate, base_dtype=torch.float32):
     )
     swap_linear_with_float8_linear(
         m,
-        Float8Linear,
         emulate=emulate,
         scaling_type_x=TensorScalingType.DELAYED,
         scaling_type_w=TensorScalingType.DELAYED,

--- a/test/test_inference_flows.py
+++ b/test/test_inference_flows.py
@@ -193,7 +193,6 @@ class TestFP8TrainToFP8LinearInference:
         fp8_mlp.reset_parameters()
         swap_linear_with_float8_linear(
             fp8_mlp,
-            Float8Linear,
             scaling_type_x=TensorScalingType.DYNAMIC,
             scaling_type_w=TensorScalingType.DYNAMIC,
             scaling_type_dL_dY=TensorScalingType.DYNAMIC,
@@ -218,7 +217,6 @@ class TestFP8TrainToFP8LinearInference:
             new_fp8_mlp = FeedForward().to(dtype=dtype)
             swap_linear_with_float8_linear(
                 new_fp8_mlp,
-                Float8Linear,
                 scaling_type_x=TensorScalingType.DYNAMIC,
                 scaling_type_w=TensorScalingType.DYNAMIC,
                 scaling_type_dL_dY=TensorScalingType.DYNAMIC,

--- a/test/test_numerics_integration.py
+++ b/test/test_numerics_integration.py
@@ -14,11 +14,9 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
 from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 from float8_experimental.float8_linear_utils import (
     linear_requires_sync,
-    LinearType,
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
 )
@@ -85,32 +83,14 @@ class TestFloat8NumericsIntegrationTest:
     @pytest.mark.parametrize(
         "scaling_type_dL_dY", [TensorScalingType.DELAYED, TensorScalingType.DYNAMIC]
     )
-    @pytest.mark.parametrize("linear_cls", [Float8Linear, Float8DynamicLinear])
     @pytest.mark.skipif(not is_H100, reason="requires H100 GPU")
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw(
         self,
-        linear_cls,
         scaling_type_x: TensorScalingType,
         scaling_type_w: TensorScalingType,
         scaling_type_dL_dY: TensorScalingType,
     ):
-        linear_type = (
-            LinearType.DELAYED if linear_cls == Float8Linear else LinearType.DYNAMIC
-        )
-        if linear_type is LinearType.DYNAMIC:
-            # Only test one combination of scaling types, as they are a no-op
-            # for Float8DynamicLinear. It would be cleaner to split into two
-            # tests, but IMO not worth it since Float8DynamicLinear will be
-            # deleted soon
-            is_all_dynamic = (
-                scaling_type_x is TensorScalingType.DYNAMIC
-                and scaling_type_w is TensorScalingType.DYNAMIC
-                and scaling_type_dL_dY is TensorScalingType.DYNAMIC
-            )
-            if not is_all_dynamic:
-                pytest.skip()
-
         # TODO(later): maybe add float16 back if it becomes important
         data_dtype = torch.bfloat16
 
@@ -130,7 +110,6 @@ class TestFloat8NumericsIntegrationTest:
         model_fp8 = copy.deepcopy(model_ref)
         swap_linear_with_float8_linear(
             model_fp8,
-            linear_cls,
             emulate=False,
             scaling_type_x=scaling_type_x,
             scaling_type_w=scaling_type_w,
@@ -156,17 +135,13 @@ class TestFloat8NumericsIntegrationTest:
         model_ref_out = model_ref(data2)
         model_ref_out.sum().backward()
 
-        if linear_requires_sync(
-            linear_type, scaling_type_x, scaling_type_w, scaling_type_dL_dY
-        ):
+        if linear_requires_sync(scaling_type_x, scaling_type_w, scaling_type_dL_dY):
             sync_float8_amax_and_scale_history(model_fp8)
         model_fp8(data1).sum().backward()
         # zero out grads without stepping, since we just want to compare grads
         # of the second datum
         optim_fp8.zero_grad()
-        if linear_requires_sync(
-            linear_type, scaling_type_x, scaling_type_w, scaling_type_dL_dY
-        ):
+        if linear_requires_sync(scaling_type_x, scaling_type_w, scaling_type_dL_dY):
             sync_float8_amax_and_scale_history(model_fp8)
         model_fp8_out = model_fp8(data2)
         model_fp8_out.sum().backward()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #304

Summary:

We are standardizing on `Float8Linear` as the only float8 linear object:
1. the stack ending with
   https://github.com/pytorch-labs/float8_experimental/pull/300 moved
   all of the functionality of `Float8DynamicLinear` to `Float8Linear`.
   The default settings of `Float8Linear` are to use dynamic scaling.
2. this PR deletes `Float8DynamicLinear` from the codebase and patches
   the relevant callsites in fbsource.

Test Plan:

```
// all tests pass
./test_everything.sh

// also run all benchmarks and verify correctness
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59342767](https://our.internmc.facebook.com/intern/diff/D59342767)