### PR TITLE
static scaling support for training

### DIFF
--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -149,6 +149,22 @@ class NormFFNResidualNorm(nn.Module):
         return x
 
 
+class SigmoidLinearLNSigmoid(nn.Module):
+    def __init__(self, d1, d2):
+        super().__init__()
+        self.sigmoid1 = nn.Sigmoid()
+        self.fc = nn.Linear(d1, d2)
+        self.ln = nn.LayerNorm(d2)
+        self.sigmoid2 = nn.Sigmoid()
+
+    def forward(self, x):
+        x = self.sigmoid1(x)
+        x = self.fc(x)
+        x = self.ln(x)
+        x = self.sigmoid2(x)
+        return x
+
+
 @dataclass
 class ProfileConfig:
     file_path: Optional[str] = None
@@ -210,7 +226,12 @@ def main(
     model_type: str = "linear",
     dtype_filter: str = "both",
 ):
-    assert model_type in ("linear", "ln_linear", "norm_ffn_norm"), "unsupported"
+    assert model_type in (
+        "linear",
+        "ln_linear",
+        "norm_ffn_norm",
+        "sigmoid_linear_ln_sigmoid",
+    ), "unsupported"
     assert dtype_filter in ("both", "float8", "bfloat16")
 
     scaling_type_x = TensorScalingType(scaling_type_x)
@@ -242,6 +263,12 @@ def main(
         input_tensor = torch.randn(
             1, 8192, 4096, device=device, dtype=ref_dtype
         ).requires_grad_()
+    elif model_type == "sigmoid_linear_ln_sigmoid":
+        bsz, d1, d2 = 4096, 4096, 4096
+        m_ref = SigmoidLinearLNSigmoid(d1, d2)
+        input_tensor = torch.randn(
+            bsz, d1, device=device, dtype=ref_dtype, requires_grad=True
+        )
     else:
         M, K, N = 4 * 4096, 8192, 7168
         m_ref = torch.nn.Sequential(
@@ -258,6 +285,15 @@ def main(
         "scaling_type_w": scaling_type_w,
         "scaling_type_dL_dY": scaling_type_dL_dY,
     }
+    if scaling_type_x is TensorScalingType.STATIC:
+        # for now, dummy scale
+        extra_kwargs["static_scale_x"] = 1.0
+    if scaling_type_w is TensorScalingType.STATIC:
+        # for now, dummy scale
+        extra_kwargs["static_scale_w"] = 1.0
+    if scaling_type_dL_dY is TensorScalingType.STATIC:
+        # for now, dummy scale
+        extra_kwargs["static_scale_dL_dY"] = 1.0
 
     m_float8 = copy.deepcopy(m_ref)
     swap_linear_with_float8_linear(m_float8, **extra_kwargs)
@@ -300,85 +336,91 @@ def main(
     # if the `TORCHINDUCTOR_PROFILE` env var is enabled, parse its output
     # to populate triton kernel bandwidth further down in the script
     f = io.StringIO()
-    with redirect_stdout(f):
-        # warm up
-        for _ in range(1):
+    try:
+        with redirect_stdout(f):
+            # warm up
+            for _ in range(1):
+                if dtype_filter != "float8":
+                    ref_forw_backward(input_tensor)
+                if dtype_filter != "bfloat16":
+                    float8_forw_backward_wrapper(input_tensor)
+
+            profile_iters = 5
+            ref_times, float8_times = None, None
+            data = []
+
             if dtype_filter != "float8":
-                ref_forw_backward(input_tensor)
+                # Profile Reference Model
+                print("profiling ref")
+                ref_suffix = f"_{model_type}_ref_compile_{compile}.json"
+                ref_path = profile_path_prefix + ref_suffix
+                profile_config = ProfileConfig(
+                    ref_path, ref_suffix, iters=profile_iters, warmup_iters=2, sync=True
+                )
+                p = profile_function(profile_config, ref_forw_backward, input_tensor)
+                print(f"saved {ref_path}")
+                ref_times = profiler_output_to_time_by_kernel_name(p)
+                total_time_ms = sum(v for v in ref_times.values()) / 1e3 / profile_iters
+                for k, v in ref_times.items():
+                    v_ms = v / 1e3 / profile_iters
+                    data.append(
+                        [
+                            "0_ref",
+                            k,
+                            kernel_name_to_category(k),
+                            v_ms,
+                            v_ms / total_time_ms,
+                            None,
+                        ]
+                    )
+
             if dtype_filter != "bfloat16":
-                float8_forw_backward_wrapper(input_tensor)
-
-        profile_iters = 5
-        ref_times, float8_times = None, None
-        data = []
-
-        if dtype_filter != "float8":
-            # Profile Reference Model
-            print("profiling ref")
-            ref_suffix = f"_{model_type}_ref_compile_{compile}.json"
-            ref_path = profile_path_prefix + ref_suffix
-            profile_config = ProfileConfig(
-                ref_path, ref_suffix, iters=profile_iters, warmup_iters=2, sync=True
-            )
-            p = profile_function(profile_config, ref_forw_backward, input_tensor)
-            print(f"saved {ref_path}")
-            ref_times = profiler_output_to_time_by_kernel_name(p)
-            total_time_ms = sum(v for v in ref_times.values()) / 1e3 / profile_iters
-            for k, v in ref_times.items():
-                v_ms = v / 1e3 / profile_iters
-                data.append(
-                    [
-                        "0_ref",
-                        k,
-                        kernel_name_to_category(k),
-                        v_ms,
-                        v_ms / total_time_ms,
-                        None,
-                    ]
+                # Profile Float8 Model
+                print("profiling float8")
+                float8_suffix = (
+                    f"_{model_type}_float8_compile_{compile}_{scaling_repr}.json"
                 )
-
-        if dtype_filter != "bfloat16":
-            # Profile Float8 Model
-            print("profiling float8")
-            float8_suffix = (
-                f"_{model_type}_float8_compile_{compile}_{scaling_repr}.json"
-            )
-            float8_path = profile_path_prefix + float8_suffix
-            profile_config = ProfileConfig(
-                float8_path,
-                float8_suffix,
-                iters=profile_iters,
-                warmup_iters=2,
-                sync=True,
-            )
-            p = profile_function(
-                profile_config, float8_forw_backward_wrapper, input_tensor
-            )
-            print(f"saved {float8_path}")
-            float8_times = profiler_output_to_time_by_kernel_name(p)
-            total_time_ms = sum(v for v in float8_times.values()) / 1e3 / profile_iters
-            for k, v in float8_times.items():
-                v_ms = v / 1e3 / profile_iters
-                data.append(
-                    [
-                        "1_float8",
-                        k,
-                        kernel_name_to_category(k),
-                        v / 1e3 / profile_iters,
-                        v_ms / total_time_ms,
-                        None,
-                    ]
+                float8_path = profile_path_prefix + float8_suffix
+                profile_config = ProfileConfig(
+                    float8_path,
+                    float8_suffix,
+                    iters=profile_iters,
+                    warmup_iters=2,
+                    sync=True,
                 )
+                p = profile_function(
+                    profile_config, float8_forw_backward_wrapper, input_tensor
+                )
+                print(f"saved {float8_path}")
+                float8_times = profiler_output_to_time_by_kernel_name(p)
+                total_time_ms = (
+                    sum(v for v in float8_times.values()) / 1e3 / profile_iters
+                )
+                for k, v in float8_times.items():
+                    v_ms = v / 1e3 / profile_iters
+                    data.append(
+                        [
+                            "1_float8",
+                            k,
+                            kernel_name_to_category(k),
+                            v / 1e3 / profile_iters,
+                            v_ms / total_time_ms,
+                            None,
+                        ]
+                    )
 
-            # get the time spent per user annotation
-            sync_time_us = profiler_output_to_gpu_time_for_key(
-                p, "scale_amax_and_scales"
-            )
-            sync_time_ms = sync_time_us / profile_iters / 1e3
-            print(f"Sync time ms: {sync_time_ms}")
+                # get the time spent per user annotation
+                sync_time_us = profiler_output_to_gpu_time_for_key(
+                    p, "scale_amax_and_scales"
+                )
+                sync_time_ms = sync_time_us / profile_iters / 1e3
+                print(f"Sync time ms: {sync_time_ms}")
 
-    # print the redirected stdout back to regular stdout
-    print(f.getvalue())
+    finally:
+        # print the redirected stdout back to regular stdout
+        # the finally clause is to help print output in the presence of exceptions,
+        # to aid local debugging
+        print(f.getvalue())
 
     # populate the triton kernel bandwidth
     for line in f.getvalue().split("\n"):

--- a/benchmarks/profile_linear_float8.py
+++ b/benchmarks/profile_linear_float8.py
@@ -287,13 +287,13 @@ def main(
     }
     if scaling_type_x is TensorScalingType.STATIC:
         # for now, dummy scale
-        extra_kwargs["static_scale_x"] = 1.0
+        extra_kwargs["static_scale_x"] = torch.tensor(1.0, device="cuda")
     if scaling_type_w is TensorScalingType.STATIC:
         # for now, dummy scale
-        extra_kwargs["static_scale_w"] = 1.0
+        extra_kwargs["static_scale_w"] = torch.tensor(1.0, device="cuda")
     if scaling_type_dL_dY is TensorScalingType.STATIC:
         # for now, dummy scale
-        extra_kwargs["static_scale_dL_dY"] = 1.0
+        extra_kwargs["static_scale_dL_dY"] = torch.tensor(1.0, device="cuda")
 
     m_float8 = copy.deepcopy(m_ref)
     swap_linear_with_float8_linear(m_float8, **extra_kwargs)

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -218,16 +218,17 @@ class Float8Linear(torch.nn.Linear):
             or self.scaling_type_dL_dY is TensorScalingType.DELAYED
         )
 
-        # TODO(future): if needed, add serializations for scalars below
         if static_scale_x is not None:
             assert self.scaling_type_x is TensorScalingType.STATIC, "unsupported"
-            self.static_scale_x_scalar = static_scale_x
+            self.register_always_float32_buffer("static_scale_x", static_scale_x)
         if static_scale_w is not None:
             assert self.scaling_type_w is TensorScalingType.STATIC, "unsupported"
-            self.static_scale_w_scalar = static_scale_w
+            self.register_always_float32_buffer("static_scale_w", static_scale_w)
         if static_scale_dL_dY is not None:
             assert self.scaling_type_dL_dY is TensorScalingType.STATIC, "unsupported"
-            self.static_scale_dL_dY_scalar = static_scale_dL_dY
+            self.register_always_float32_buffer(
+                "static_scale_dL_dY", static_scale_dL_dY
+            )
 
         # TODO(future): have a unique recipe per buffer instead of one per
         # module, saving implementing that until we need it.
@@ -306,24 +307,6 @@ class Float8Linear(torch.nn.Linear):
             )
             self.register_always_float32_buffer(
                 "fp8_scale_dL_dY", torch.tensor([1.0], device=device)
-            )
-
-        # TODO(before land): good error message if user specified static scale type
-        # but did not provide a value
-        if self.scaling_type_x is TensorScalingType.STATIC:
-            self.register_always_float32_buffer(
-                "static_scale_x",
-                torch.tensor([self.static_scale_x_scalar], device=device),
-            )
-        if self.scaling_type_w is TensorScalingType.STATIC:
-            self.register_always_float32_buffer(
-                "static_scale_w",
-                torch.tensor([self.static_scale_w_scalar], device=device),
-            )
-        if self.scaling_type_dL_dY is TensorScalingType.STATIC:
-            self.register_always_float32_buffer(
-                "static_scale_dL_dY",
-                torch.tensor([self.static_scale_dL_dY_scalar], device=device),
             )
 
     def register_always_float32_buffer(

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -136,8 +136,6 @@ class NoopFwToFloat8E5M2BwStatic(torch.autograd.Function):
     @staticmethod
     def backward(ctx, go):
         (static_scale_dL_dY,) = ctx.saved_tensors
-        print("STATIC SCALE", static_scale_dL_dY)
-
         res = to_fp8_no_autograd(
             go, static_scale_dL_dY, e5m2_dtype, mm_config=ctx.mm_config
         )

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -154,6 +154,9 @@ def swap_linear_with_float8_linear(
     scaling_type_x: TensorScalingType = TensorScalingType.DYNAMIC,
     scaling_type_w: TensorScalingType = TensorScalingType.DYNAMIC,
     scaling_type_dL_dY: TensorScalingType = TensorScalingType.DYNAMIC,
+    static_scale_x: Optional[float] = None,
+    static_scale_w: Optional[float] = None,
+    static_scale_dL_dY: Optional[float] = None,
 ) -> Optional[nn.Module]:
     """
     Swaps `torch.nn.Linear` in `module` with `Float8Linear`.
@@ -167,6 +170,9 @@ def swap_linear_with_float8_linear(
         scaling_type_x (TensorScalingType): scaling type for `x`
         scaling_type_w (TensorScalingType): scaling type for `w`
         scaling_type_dL_dY (TensorScalingType): scaling type for `dL_dY`
+        static_scale_x: static scale for `x`
+        static_scale_w: static scale for `w`
+        static_scale_dL_dY: static scale for `dL_dY`
 
     Returns:
      nn.Module: The modified module with swapped linear layers.
@@ -177,6 +183,9 @@ def swap_linear_with_float8_linear(
         scaling_type_x=scaling_type_x,
         scaling_type_w=scaling_type_w,
         scaling_type_dL_dY=scaling_type_dL_dY,
+        static_scale_x=static_scale_x,
+        static_scale_w=static_scale_w,
+        static_scale_dL_dY=static_scale_dL_dY,
     )
     return swap_linear_layers(
         module,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #306
* #307

Summary:

Some activations such as sigmoid can have a bounded range.  This PR adds support for setting a bounded range in training.

Test Plan:

```
// unit tests
pytest test/test_base.py

// baseline
> python benchmarks/profile_linear_float8.py ~/local/tmp/test --model_type sigmoid_linear
...
 experiment     0_ref  1_float8  f8_div_ref  ref_div_f8
category                                              
0_gemm         0.637     0.353       0.555       1.803
1_f8_overhead  0.000     0.175         inf       0.000
2_other        0.224     0.199       0.888       1.126
All            0.861     0.727       0.844       1.184

> python benchmarks/profile_linear_float8.py ~/local/tmp/test --model_type sigmoid_linear --scaling_type_x static
...
 experiment     0_ref  1_float8  f8_div_ref  ref_div_f8
category                                              
0_gemm         0.635     0.360       0.566       1.766
1_f8_overhead  0.000     0.182         inf       0.000
2_other        0.224     0.154       0.688       1.454
All            0.859     0.696       0.810       1.234

```

Reviewers:

Subscribers:

Tasks:

Tags: