### PR TITLE
make all 3 gemms in Float8Linear support configurability, not user facing

### DIFF
--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -8,12 +8,13 @@ from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
+    LinearMMConfig,
     ScaledMMConfig,
 )
 
 # Needed to load Float8Tensor with weights_only = True
 from torch.serialization import add_safe_globals
 
-add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole])
+add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole, LinearMMConfig])
 
 __all__ = ["Float8Tensor", "Float8Linear"]

--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -5,11 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
 from float8_experimental.float8_linear import Float8Linear
-from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig, GemmInputRole
 
 # Needed to load Float8Tensor with weights_only = True
 from torch.serialization import add_safe_globals
 
-add_safe_globals([Float8Tensor, ScaledMMConfig])
+add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole])
 
 __all__ = ["Float8Tensor", "Float8Linear"]

--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -5,7 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
 from float8_experimental.float8_linear import Float8Linear
-from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig, GemmInputRole
+from float8_experimental.float8_tensor import (
+    Float8Tensor,
+    GemmInputRole,
+    ScaledMMConfig,
+)
 
 # Needed to load Float8Tensor with weights_only = True
 from torch.serialization import add_safe_globals

--- a/float8_experimental/float8_dynamic_utils.py
+++ b/float8_experimental/float8_dynamic_utils.py
@@ -10,7 +10,8 @@ import torch
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
-    ScaledMMConfig,
+    GemmInputRole,
+    LinearMMConfig,
     tensor_already_casted_to_fp8,
     to_fp8_no_autograd,
 )
@@ -28,9 +29,9 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
     def forward(
         ctx,
         tensor,
-        mm_config: ScaledMMConfig,
+        linear_mm_config: LinearMMConfig,
     ):
-        ctx.mm_config = mm_config
+        ctx.linear_mm_config = linear_mm_config
         return tensor
 
     @staticmethod
@@ -39,21 +40,34 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
             return gradY, None
         gradY_scale = tensor_to_scale(gradY, e5m2_dtype)
         fp8_tensor = to_fp8_no_autograd(
-            gradY, gradY_scale, e5m2_dtype, mm_config=ctx.mm_config
+            gradY,
+            gradY_scale,
+            e5m2_dtype,
+            linear_mm_config=ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.DL_DY,
         )
         return fp8_tensor, None
 
 
 def cast_to_float8_e4m3_dynamic(
-    inpt_tensor: torch.Tensor, mm_config: ScaledMMConfig, reduce_amax: bool = False
+    inpt_tensor: torch.Tensor,
+    linear_mm_config: LinearMMConfig,
+    reduce_amax: bool = False,
+    gemm_input_role: GemmInputRole = GemmInputRole.X,
 ) -> Float8Tensor:
     if tensor_already_casted_to_fp8(inpt_tensor):
         return inpt_tensor
     scale = tensor_to_scale(inpt_tensor, e4m3_dtype, reduce_amax)
-    return Float8Tensor.to_float8(inpt_tensor, scale, e4m3_dtype, mm_config=mm_config)
+    return Float8Tensor.to_float8(
+        inpt_tensor,
+        scale,
+        e4m3_dtype,
+        linear_mm_config=linear_mm_config,
+        gemm_input_role=gemm_input_role,
+    )
 
 
 def cast_to_float8_e5m2_dynamic_bw(
-    gradY: torch.Tensor, mm_config: ScaledMMConfig
+    gradY: torch.Tensor, linear_mm_config: LinearMMConfig
 ) -> torch.Tensor:
-    return NoopFwToFloat8E5M2Bw.apply(gradY, mm_config)
+    return NoopFwToFloat8E5M2Bw.apply(gradY, linear_mm_config)

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -471,10 +471,9 @@ class Float8Linear(torch.nn.Linear):
         if config.enable_fsdp_fp8_all_gather:
             if scaling_type_w is TensorScalingType.DYNAMIC:
                 new_mod.weight = torch.nn.Parameter(
-                    # TODO(this PR): change callsites below to linear_mm_config
                     WeightWithDynamicFloat8CastTensor(
                         new_mod.weight,
-                        new_mod.forward_config,
+                        new_mod.linear_mm_config,
                     )
                 )
             else:
@@ -485,7 +484,7 @@ class Float8Linear(torch.nn.Linear):
                         new_mod.fp8_amax_w,
                         new_mod.fp8_amax_history_w,
                         new_mod.fp8_scale_w,
-                        new_mod.forward_config,
+                        new_mod.linear_mm_config,
                         new_mod.is_amax_initialized,
                     )
                 )

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -23,6 +23,8 @@ from float8_experimental.float8_dynamic_utils import (
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
+    GemmInputRole,
+    LinearMMConfig,
     ScaledMMConfig,
     to_fp8_no_autograd,
 )
@@ -85,12 +87,12 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
         fp8_scale_dL_dY,
         scale_fn_name,
         is_amax_initialized,
-        mm_config: ScaledMMConfig,
+        linear_mm_config: LinearMMConfig,
     ):
         ctx.save_for_backward(fp8_amax_dL_dY, fp8_amax_history_dL_dY, fp8_scale_dL_dY)
         ctx.scale_fn_name = scale_fn_name
         ctx.is_amax_initialized = is_amax_initialized
-        ctx.mm_config = mm_config
+        ctx.linear_mm_config = linear_mm_config
         return tensor
 
     @staticmethod
@@ -113,7 +115,11 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
         fp8_amax_dL_dY.fill_(tensor_to_amax(go))
 
         res = to_fp8_no_autograd(
-            go, fp8_scale_dL_dY, e5m2_dtype, mm_config=ctx.mm_config
+            go,
+            fp8_scale_dL_dY,
+            e5m2_dtype,
+            linear_mm_config=ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.DL_DY,
         )
         empty_grads = None, None, None, None, None, None
         return res, *empty_grads
@@ -192,12 +198,18 @@ class Float8Linear(torch.nn.Linear):
 
         self.create_buffers()
 
-        # Defines the behavior of the matmul in the forward and backward pass
-        self.forward_config = ScaledMMConfig(
-            emulate, True if not emulate else False, False, config.pad_inner_dim
-        )
-        self.backward_config = ScaledMMConfig(
-            emulate, False, False, config.pad_inner_dim
+        # TODO(future): user level configuration of gemms
+        self.linear_mm_config = LinearMMConfig(
+            # x
+            ScaledMMConfig(
+                emulate, True if not emulate else False, False, config.pad_inner_dim
+            ),
+            # w
+            ScaledMMConfig(
+                emulate, True if not emulate else False, False, config.pad_inner_dim
+            ),
+            # dL_dY
+            ScaledMMConfig(emulate, False, False, config.pad_inner_dim),
         )
 
         # Note: is_amax_initialized is not a buffer to avoid data dependent
@@ -308,11 +320,12 @@ class Float8Linear(torch.nn.Linear):
                 self.fp8_scale_x,
                 e4m3_dtype,
                 self.fp8_amax_x,
-                self.forward_config,
+                linear_mm_config=self.linear_mm_config,
+                gemm_input_role=GemmInputRole.X,
             )
         else:
             assert self.scaling_type_x is TensorScalingType.DYNAMIC
-            x_fp8 = cast_to_float8_e4m3_dynamic(x, self.forward_config)
+            x_fp8 = cast_to_float8_e4m3_dynamic(x, self.linear_mm_config)
         return x_fp8
 
     def cast_w_to_float8(
@@ -339,14 +352,17 @@ class Float8Linear(torch.nn.Linear):
                     self.fp8_scale_w,
                     e4m3_dtype,
                     self.fp8_amax_w,
-                    self.forward_config,
+                    linear_mm_config=self.linear_mm_config,
+                    gemm_input_role=GemmInputRole.W,
                 )
         else:
             assert self.scaling_type_w is TensorScalingType.DYNAMIC
             if isinstance(self.weight, Float8Tensor):  # cast by FSDP
                 w_fp8 = self.weight
             else:
-                w_fp8 = cast_to_float8_e4m3_dynamic(self.weight, self.forward_config)
+                w_fp8 = cast_to_float8_e4m3_dynamic(
+                    self.weight, self.linear_mm_config, gemm_input_role=GemmInputRole.W
+                )
         return w_fp8
 
     def cast_y_to_float8_in_bw(self, y: torch.Tensor) -> torch.Tensor:
@@ -359,11 +375,11 @@ class Float8Linear(torch.nn.Linear):
                 self.fp8_scale_dL_dY,
                 scale_fn_name,
                 self.is_amax_initialized,
-                self.backward_config,
+                self.linear_mm_config,
             )
         else:
             assert self.scaling_type_dL_dY is TensorScalingType.DYNAMIC
-            y = cast_to_float8_e5m2_dynamic_bw(y, self.backward_config)
+            y = cast_to_float8_e5m2_dynamic_bw(y, self.linear_mm_config)
         return y
 
     def float8_pre_forward(self, x):
@@ -455,6 +471,7 @@ class Float8Linear(torch.nn.Linear):
         if config.enable_fsdp_fp8_all_gather:
             if scaling_type_w is TensorScalingType.DYNAMIC:
                 new_mod.weight = torch.nn.Parameter(
+                    # TODO(this PR): change callsites below to linear_mm_config
                     WeightWithDynamicFloat8CastTensor(
                         new_mod.weight,
                         new_mod.forward_config,

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -9,10 +9,9 @@ import torch
 
 from float8_experimental.float8_python_api import addmm_float8_unwrapped
 from float8_experimental.float8_tensor import (
-    Float8Tensor,
-    merge_mm_configs,
-    ScaledMMConfig,
     choose_scaled_mm_config,
+    Float8Tensor,
+    ScaledMMConfig,
 )
 from float8_experimental.float8_utils import is_row_major, pad_tensor_for_matmul
 
@@ -51,7 +50,11 @@ def implements(aten_ops):
 def float8_desugar_op(aten_op, args, kwargs=None):
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
     return Float8Tensor(
-        new_data, args[0]._scale, args[0]._orig_dtype, args[0]._mm_config
+        new_data,
+        args[0]._scale,
+        args[0]._orig_dtype,
+        args[0]._mm_config,
+        args[0]._gemm_input_role,
     )
 
 
@@ -61,7 +64,11 @@ def float8_split(aten_op, args, kwargs=None):
 
     def make_float8(data):
         return Float8Tensor(
-            data, args[0]._scale, args[0]._orig_dtype, args[0]._mm_config
+            data,
+            args[0]._scale,
+            args[0]._orig_dtype,
+            args[0]._mm_config,
+            args[0]._gemm_input_role,
         )
 
     out = map(make_float8, new_data_tensors)
@@ -77,6 +84,7 @@ def float8_cat(aten_op, args, kwargs=None):
     scale = chunked_tensors[0]._scale
     mm_config = chunked_tensors[0]._mm_config
     fp8_dtype = chunked_tensors[0]._data.dtype
+    gemm_input_role = chunked_tensors[0]._gemm_input_role
     chunk_data = []
     for chunk in chunked_tensors:
         assert isinstance(
@@ -94,11 +102,14 @@ def float8_cat(aten_op, args, kwargs=None):
         assert (
             chunk._data.dtype == fp8_dtype
         ), "Expecting all chunks to be of the same dtype as a result of a split"
+        assert (
+            chunk._gemm_input_role is gemm_input_role
+        ), "Expecting all chunks to have the same gemm_input_role as a result of a split"
         chunk_data.append(chunk._data.view(torch.uint8))
 
     new_data = aten_op(chunk_data, *args[1:], **kwargs)
     new_data = new_data.view(fp8_dtype)
-    return Float8Tensor(new_data, scale, orig_dtype, mm_config)
+    return Float8Tensor(new_data, scale, orig_dtype, mm_config, gemm_input_role)
 
 
 @implements([aten.sum.dim_IntList])
@@ -127,8 +138,10 @@ def preprocess_addmm(a: Float8Tensor, b: Float8Tensor):
     b_data = b._data
 
     scaled_mm_config = choose_scaled_mm_config(
-        a._gemm_input_role, a._mm_config,
-        b._gemm_input_role, b._mm_config,
+        a._gemm_input_role,
+        a._mm_config,
+        b._gemm_input_role,
+        b._mm_config,
     )
 
     if scaled_mm_config.pad_inner_dim:
@@ -162,12 +175,11 @@ def float8_mm(aten_op, args, kwargs=None):
     )
     a_data, a_scale, b_data, b_scale = preprocess_addmm(a, b)
     output_dtype = a._orig_dtype
-    # a_mm_config: ScaledMMConfig = a._mm_config
-    # b_mm_config: ScaledMMConfig = b._mm_config
-    # mm_config: ScaledMMConfig = merge_mm_configs(a_mm_config, b_mm_config)
     scaled_mm_config = choose_scaled_mm_config(
-        a._gemm_input_role, a._mm_config,
-        b._gemm_input_role, b._mm_config,
+        a._gemm_input_role,
+        a._mm_config,
+        b._gemm_input_role,
+        b._mm_config,
     )
     if scaled_mm_config.emulate:
         return torch.ops.aten.mm_float8_emulated(
@@ -199,12 +211,11 @@ def float8_addmm(aten_op, args, kwargs=None):
     a_data, a_scale, b_data, b_scale = preprocess_addmm(a, b)
     output_dtype = a._orig_dtype
     assert bias.dtype == output_dtype, "bias dtype must match output dtype"
-    # a_mm_config: ScaledMMConfig = a._mm_config
-    # b_mm_config: ScaledMMConfig = b._mm_config
-    # mm_config: ScaledMMConfig = merge_mm_configs(a_mm_config, b_mm_config)
     scaled_mm_config = choose_scaled_mm_config(
-        a._gemm_input_role, a._mm_config,
-        b._gemm_input_role, b._mm_config,
+        a._gemm_input_role,
+        a._mm_config,
+        b._gemm_input_role,
+        b._mm_config,
     )
     if scaled_mm_config.emulate:
         out = torch.ops.aten.mm_float8_emulated(
@@ -244,7 +255,11 @@ def autocast_to_copy(aten_op, args, kwargs=None):
         torch.bfloat16,
     }, "Only support floating point conversion for autocast w/ Float8Tensor"
     return Float8Tensor(
-        args[0]._data, args[0]._scale, kwargs["dtype"], args[0]._mm_config
+        args[0]._data,
+        args[0]._scale,
+        kwargs["dtype"],
+        args[0]._mm_config,
+        args[0]._gemm_input_role,
     )
 
 
@@ -267,7 +282,11 @@ def allgather_fp8(aten_op, args, kwargs=None):
     fp8_data = fp8_data.contiguous()
     fp8_out = aten_op(fp8_data, *args[1:], **kwargs)
     return Float8Tensor(
-        fp8_out, fp8_input._scale, fp8_input._orig_dtype, fp8_input._mm_config
+        fp8_out,
+        fp8_input._scale,
+        fp8_input._orig_dtype,
+        fp8_input._mm_config,
+        fp8_input._gemm_input_role,
     )
 
 
@@ -279,7 +298,11 @@ def wait_tensor_fp8(aten_op, args, kwargs=None):
     fp8_data = fp8_input._data
     fp8_out = aten_op(fp8_data, *args[1:], **kwargs)
     return Float8Tensor(
-        fp8_out, fp8_input._scale, fp8_input._orig_dtype, fp8_input._mm_config
+        fp8_out,
+        fp8_input._scale,
+        fp8_input._orig_dtype,
+        fp8_input._mm_config,
+        fp8_input._gemm_input_role,
     )
 
 
@@ -297,7 +320,11 @@ def index_put_fp8(aten_op, args, kwargs=None):
     fp8_values_data = fp8_values._data
     fp8_out = aten_op(fp8_data, args[1], fp8_values_data, *args[3:], **kwargs)
     return Float8Tensor(
-        fp8_out, fp8_self._scale, fp8_self._orig_dtype, fp8_self._mm_config
+        fp8_out,
+        fp8_self._scale,
+        fp8_self._orig_dtype,
+        fp8_self._mm_config,
+        fp8_self._gemm_input_role,
     )
 
 
@@ -329,7 +356,16 @@ def copy_fp8(aten_op, args, kwargs=None):
         assert (
             self._data.dtype == src._data.dtype
         ), "Expecting both Float8Tensors to be of the same dtypet"
+        assert (
+            self._gemm_input_role == src._gemm_input_role
+        ), "Expecting both Float8Tensors to have the same gemm_input_role"
         fp8_out = aten_op(self._data, src._data, *args[2:], **kwargs)
-        return Float8Tensor(fp8_out, self._scale, self._orig_dtype, self._mm_config)
+        return Float8Tensor(
+            fp8_out,
+            self._scale,
+            self._orig_dtype,
+            self._mm_config,
+            self._gemm_input_role,
+        )
     else:
         raise RuntimeError("Unsupported semantics for copy_ in Float8Tensor")

--- a/float8_experimental/fsdp_utils.py
+++ b/float8_experimental/fsdp_utils.py
@@ -12,11 +12,7 @@ import torch.nn as nn
 import torch.utils._pytree as pytree
 from float8_experimental.float8_dynamic_utils import cast_to_float8_e4m3_dynamic
 
-from float8_experimental.float8_tensor import (
-    Float8Tensor,
-    merge_mm_configs,
-    ScaledMMConfig,
-)
+from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
 
 from float8_experimental.float8_utils import e4m3_dtype, EPS
 from torch._prims_common import suggest_memory_format
@@ -129,7 +125,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
             if mm_config is None:
                 mm_config = t._mm_config
             else:
-                mm_config = merge_mm_configs(mm_config, t._mm_config)
+                assert t._mm_config == mm_config
             return t._tensor
 
         args, kwargs = pytree.tree_map_only(
@@ -257,7 +253,7 @@ class WeightWithDelayedFloat8CastTensor(torch.Tensor):
             if mm_config is None:
                 mm_config = t._mm_config
             else:
-                mm_config = merge_mm_configs(mm_config, t._mm_config)
+                assert t._mm_config == mm_config
             nonlocal amax_buffer
             if amax_buffer is None:
                 amax_buffer = t._amax_buffer

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -20,6 +20,7 @@ from float8_experimental.float8_linear_utils import swap_linear_layers
 
 from float8_experimental.float8_tensor import (
     Float8Tensor,
+    GemmInputRole,
     ScaledMMConfig,
     tensor_already_casted_to_fp8,
     to_fp8_no_autograd,
@@ -126,6 +127,7 @@ class Float8InferenceLinear(torch.nn.Linear):
             scale,
             dtype,
             self.forward_config,
+            gemm_input_role=GemmInputRole.W,
         )
         self.weight = nn.Parameter(quantized_weight)
         self.weight.requires_grad = False

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -28,6 +28,7 @@ from float8_experimental.float8_tensor import (
     Float8Tensor,
     merge_mm_configs,
     ScaledMMConfig,
+    GemmInputRole,
 )
 from float8_experimental.float8_utils import (
     compute_error,
@@ -438,9 +439,9 @@ class TestScaledMM:
         x_fp32 = torch.randn(16, 16, device="cuda")
         x_scale = torch.tensor(1.0, device="cuda")
         fp8_dtype = e4m3_dtype
-        a = Float8Tensor.to_float8(x_fp32, x_scale, fp8_dtype)
+        a = Float8Tensor.to_float8(x_fp32, x_scale, fp8_dtype, gemm_input_role=GemmInputRole.X)
         b = Float8Tensor.to_float8(
-            x_fp32, x_scale, fp8_dtype, mm_config=ScaledMMConfig(True)
+            x_fp32, x_scale, fp8_dtype, mm_config=ScaledMMConfig(True), gemm_input_role=GemmInputRole.W
         )
         with pytest.raises(
             AssertionError,

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -26,9 +26,9 @@ from float8_experimental.float8_linear_utils import (
 from float8_experimental.float8_python_api import addmm_float8_unwrapped
 from float8_experimental.float8_tensor import (
     Float8Tensor,
-    merge_mm_configs,
-    ScaledMMConfig,
     GemmInputRole,
+    LinearMMConfig,
+    ScaledMMConfig,
 )
 from float8_experimental.float8_utils import (
     compute_error,
@@ -439,37 +439,35 @@ class TestScaledMM:
         x_fp32 = torch.randn(16, 16, device="cuda")
         x_scale = torch.tensor(1.0, device="cuda")
         fp8_dtype = e4m3_dtype
-        a = Float8Tensor.to_float8(x_fp32, x_scale, fp8_dtype, gemm_input_role=GemmInputRole.X)
+        linear_config_a = LinearMMConfig(
+            ScaledMMConfig(False, True, False, False),
+            ScaledMMConfig(False, False, False, False),
+            ScaledMMConfig(False, False, False, False),
+        )
+        linear_config_b = LinearMMConfig(
+            ScaledMMConfig(True, True, False, False),
+            ScaledMMConfig(True, False, False, False),
+            ScaledMMConfig(True, False, False, False),
+        )
+        a = Float8Tensor.to_float8(
+            x_fp32,
+            x_scale,
+            fp8_dtype,
+            linear_mm_config=linear_config_a,
+            gemm_input_role=GemmInputRole.X,
+        )
         b = Float8Tensor.to_float8(
-            x_fp32, x_scale, fp8_dtype, mm_config=ScaledMMConfig(True), gemm_input_role=GemmInputRole.W
+            x_fp32,
+            x_scale,
+            fp8_dtype,
+            linear_mm_config=linear_config_b,
+            gemm_input_role=GemmInputRole.W,
         )
         with pytest.raises(
             AssertionError,
-            match="Both mm_configs must have the same emulate value, but got False and True",
+            match="linear_mm_config.y mismatch",
         ):
             a @ b
-
-    def test_merge_configs(self):
-        a = ScaledMMConfig(False, True, True)
-        b = ScaledMMConfig(True, False, False)
-        with pytest.raises(
-            AssertionError,
-            match="Both mm_configs must have the same emulate value, but got False and True",
-        ):
-            merge_mm_configs(a, b)
-        a = ScaledMMConfig(False, True, True)
-        b = ScaledMMConfig(False, False, False)
-        c = merge_mm_configs(a, b)
-        assert c.emulate is False
-        assert c.use_fast_accum is False
-        assert c.fp8_output is False
-
-        a = ScaledMMConfig(False, True, False)
-        b = ScaledMMConfig(False, True, False)
-        c = merge_mm_configs(a, b)
-        assert c.emulate is False
-        assert c.use_fast_accum is True
-        assert c.fp8_output is False
 
     @unittest.skipIf(
         not is_H100,
@@ -490,8 +488,12 @@ class TestScaledMM:
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
 
-        a_fp8 = Float8Tensor.to_float8(a, a_scale, input_dtype)
-        b_fp8 = Float8Tensor.to_float8(b, b_scale, input_dtype)
+        a_fp8 = Float8Tensor.to_float8(
+            a, a_scale, input_dtype, gemm_input_role=GemmInputRole.X
+        )
+        b_fp8 = Float8Tensor.to_float8(
+            b, b_scale, input_dtype, gemm_input_role=GemmInputRole.W
+        )
 
         with pytest.raises(
             RuntimeError,
@@ -501,19 +503,47 @@ class TestScaledMM:
         ):
             a_fp8 @ b_fp8
 
-        pad_config = ScaledMMConfig(False, use_fast_accum, False, True)
+        scaled_mm_config = ScaledMMConfig(False, use_fast_accum, False, True)
+        pad_config = LinearMMConfig(
+            scaled_mm_config, scaled_mm_config, scaled_mm_config
+        )
 
-        a_fp8 = Float8Tensor.to_float8(a, a_scale, input_dtype, mm_config=pad_config)
-        b_fp8 = Float8Tensor.to_float8(b, b_scale, input_dtype, mm_config=pad_config)
+        a_fp8 = Float8Tensor.to_float8(
+            a,
+            a_scale,
+            input_dtype,
+            linear_mm_config=pad_config,
+            gemm_input_role=GemmInputRole.X,
+        )
+        b_fp8 = Float8Tensor.to_float8(
+            b,
+            b_scale,
+            input_dtype,
+            linear_mm_config=pad_config,
+            gemm_input_role=GemmInputRole.W,
+        )
         out_padded = a_fp8 @ b_fp8
         out_padded.to(compare_type)
 
-        emulated_conifg = ScaledMMConfig(True, use_fast_accum, False, False)
+        emulated_scaled_mm_config = ScaledMMConfig(True, use_fast_accum, False, False)
+        emulated_config = LinearMMConfig(
+            emulated_scaled_mm_config,
+            emulated_scaled_mm_config,
+            emulated_scaled_mm_config,
+        )
         a_fp8 = Float8Tensor.to_float8(
-            a, a_scale, input_dtype, mm_config=emulated_conifg
+            a,
+            a_scale,
+            input_dtype,
+            linear_mm_config=emulated_config,
+            gemm_input_role=GemmInputRole.X,
         )
         b_fp8 = Float8Tensor.to_float8(
-            b, b_scale, input_dtype, mm_config=emulated_conifg
+            b,
+            b_scale,
+            input_dtype,
+            linear_mm_config=emulated_config,
+            gemm_input_role=GemmInputRole.W,
         )
         out_emualted = a_fp8 @ b_fp8
         out_emualted.to(compare_type)
@@ -565,8 +595,8 @@ class TestFloat8LinearUtils(unittest.TestCase):
             module = nn.Linear(3, 3)
             module = swap_linear_with_float8_linear(module, emulate=emulate)
             self.assertIsInstance(module, Float8Linear)
-            self.assertEqual(module.forward_config.emulate, emulate)
-            self.assertEqual(module.backward_config.emulate, emulate)
+            self.assertEqual(module.linear_mm_config.y.emulate, emulate)
+            self.assertEqual(module.linear_mm_config.y.emulate, emulate)
 
     def test_swap_root_linear_with_children_raises(self):
         for emulate in [True, False]:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -122,7 +122,7 @@ class TestFloat8Tensor(unittest.TestCase):
             torch.empty(16, dtype=torch.float8_e4m3fn),
             scale_a,
             torch.bfloat16,
-            fp8_a._mm_config,
+            fp8_a._linear_mm_config,
         )
         fp8_b.copy_(fp8_a)
         torch.testing.assert_close(fp8_a._data, fp8_b._data)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -19,7 +19,7 @@ from float8_experimental.float8_linear_utils import (
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
 )
-from float8_experimental.float8_tensor import Float8Tensor, ScaledMMConfig
+from float8_experimental.float8_tensor import Float8Tensor, LinearMMConfig
 from float8_experimental.float8_utils import e4m3_dtype
 
 from torch._dynamo.test_case import TestCase as DynamoTestCase
@@ -179,7 +179,7 @@ class TestGraphBreaks(DynamoTestCase):
                 self.fp8_scale_x,
                 e4m3_dtype,
                 self.fp8_amax_x,
-                ScaledMMConfig(),
+                LinearMMConfig(),
             )
             if self.graph_break:
                 torch._dynamo.graph_break()
@@ -242,9 +242,9 @@ class TestGraphBreaks(DynamoTestCase):
             type(y_compiled._orig_dtype)
         )
         assert isinstance(
-            y_compiled._mm_config.emulate, bool
+            y_compiled._linear_mm_config.y.emulate, bool
         ), "Float8Tensor._emulate should be a bool but got {}".format(
-            type(y_compiled._mm_config.emulate)
+            type(y_compiled._linear_mm_config.y.emulate)
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #315

Summary:

This PR adds some plumbing for how to eventually make all 3 gemms in a linear fwd/bwd configurable:
1. add `LinearMMConfig` to `Float8Tensor` to tie together the three `ScaledMMConfig` objects, one per gemm
2. add `GemmInputRole` to `Float8Tensor` to specify how to pick the right config
3. plumb all of these throughout the codebase

Note that none of this is user facing, and there is no logic change.  Planned follow-ups:
* a future PR will make the per-gemm behavior configurable in a user facing way, which will hook up to the objects introduced in this PR
* a future PR will update the naming from x/w/dL_dY to input/weight/grad_output throughout the codebase

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D59973551](https://our.internmc.facebook.com/intern/diff/D59973551)