### PR TITLE
[bc breaking] unify filtering functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,19 @@ from float8_experimental.fsdp_utils import precompute_float8_dynamic_scale_for_f
 # create model
 m = Model(...)
 
+# optional: filter layers from being eligible for float8 conversion
+def layer_filter_fn(fqn: str, mod: torch.nn.Module):
+    # don't convert the output layer
+    if fqn == "output":
+        return False
+    # don't convert linear layers with weight dimensions not divisible by 16
+    if isinstance(mod, torch.nn.Linear):
+        if mod.in_features % 16 != 0 or mod.out_features % 16 != 0:
+            return False
+    return True
+
 # convert all `torch.nn.Linear` modules to `Float8Linear`
-swap_linear_with_float8_linear(m)
+swap_linear_with_float8_linear(m, layer_filter_fn=layer_filter_fn)
 
 # optional: use FSDP
 model = FSDP(model, use_orig_params=True)

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -10,7 +10,7 @@ Defines an nn module designed to be used during inference
 from dataclasses import dataclass
 
 from enum import auto, Enum
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import float8_experimental.config as config
 
@@ -197,7 +197,7 @@ def quantize_to_float8(
     module: nn.Module,
     quant_config: QuantConfig,
     *,
-    skip_fqn_list: Optional[List[str]] = None,
+    layer_filter_fn: Optional[Callable[[str, nn.Module], bool]] = None,
     use_fast_accum: bool = True,
 ) -> Optional[nn.Module]:
     """
@@ -210,7 +210,9 @@ def quantize_to_float8(
     Args:
         module (nn.Module): The module to modify.
         quant_config (QuantConfig): Quantization configuration for Float8 conversion.
-        skip_fqn_list (List[str], optional): List of module FQNs to skip during conversion.
+        layer_filter_fn: If specified, only the modules that
+            that pass the filter function will be swapped. The inputs to the
+            filter function are the FQN and module instance.
         use_fast_accum : Whether to enable fast accumulation for the Float8InferenceLinear. Defaults to True.
 
     Returns:
@@ -222,5 +224,5 @@ def quantize_to_float8(
     return swap_linear_layers(
         module,
         lambda m: Float8InferenceLinear.from_float(m, quant_config, use_fast_accum),
-        skip_fqn_list=skip_fqn_list,
+        layer_filter_fn=layer_filter_fn,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #323
* __->__ #322

Summary:

Before this PR, we had two top level filtering affordances on `swap_linear_with_float8_linear`: `skip_fqn_list` and `linear_layer_filter`:

```
def swap_linear_with_float8_linear(
    ...,
    skip_fqn_list: Optional[List[str]] = None,
    linear_layer_filter: Optional[Callable[[nn.Linear], bool]] = None,
)
```

This PR unifies them into a single filtering method which is aware of both the FQN as well as the module instance.  This should be more future proof and allow for more fine grained filtering.

```
def swap_linear_with_float8_linear(
    ...,
    layer_filter_fn: Optional[Callable[[str, nn.Module], bool]] = None,
)

```

Note that the `filter_out_small_unaligned_layers` function is removed from the public API, and users are encouraged to write their own, again to make this more future proof.  I'm not opposed to adding good utility functions back at some point, but IMO we should finalize the main UX first.

Note that in the future (as outlined in the Meta-only UX discussion doc), we may change this function from being just a filter to also providing the float8 per-module config.  I'm saving that for a separate PR, which will also be BC breaking (but we don't have BC yet).

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60072597](https://our.internmc.facebook.com/intern/diff/D60072597)