### PR TITLE
[bc breaking] move most previously-global configs to Float8LinearConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ from float8_experimental.float8_linear import TensorScalingType
 # create model
 m = Model(...)
 
+# optional: configure for compatibility with FSDP. Note that workarounds 
+# gated with config.enable_amax_init and
+# config.enable_pre_and_post_forward are needed for 
+# autocast + compile + FSDP + float8 to work
+from float8_experimental import Float8LinearConfig
+config = Float8LinearConfig(
+    enable_amax_init = False,  # only needed for autocast + compile + FSDP +  float8 delayed
+    enable_pre_and_post_forward, False  # only needed for autocast + compile + FSDP +  float8 delayed
+)
+
 # convert all `torch.nn.Linear` modules to `Float8Linear`, specifying scaling
 # type
 swap_linear_with_float8_linear(
@@ -98,13 +108,10 @@ swap_linear_with_float8_linear(
     scaling_type_input=TensorScalingType.DELAYED,
     scaling_type_weight=TensorScalingType.DELAYED,
     scaling_type_grad_output=TensorScalingType.DELAYED,
+    config=config,
 )
 
-# optional: use FSDP. Note that workarounds gated with config.enable_amax_init and
-# config.enable_pre_and_post_forward are needed for autocast + compile + FSDP + float8 to work
-from float8_experimental import config
-config.enable_amax_init = False  # only needed for autocast + compile + FSDP +  float8 delayed
-config.enable_pre_and_post_forward = False  # only needed for autocast + compile + FSDP +  float8 delayed
+# optional: use FSDP
 model = FSDP(model, use_orig_params=True)
 
 # optional: enable torch.compile for improved performance

--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
+from float8_experimental.config import Float8LinearConfig
 from float8_experimental.float8_linear import Float8Linear
+from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
@@ -17,4 +19,12 @@ from torch.serialization import add_safe_globals
 
 add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole, LinearMMConfig])
 
-__all__ = ["Float8Tensor", "Float8Linear"]
+__all__ = [
+    # configuration
+    "Float8LinearConfig",
+    # top level UX
+    "swap_linear_with_float8_linear",
+    # TODO(future): remove Float8Tensor and Float8Linear from public API
+    "Float8Tensor",
+    "Float8Linear",
+]

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -7,7 +7,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Float8LinearConfig:
     """
     Configuration for converting a `torch.nn.Linear` module to float8

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -4,28 +4,36 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-# If True, on the first iteration of Float8Linear the amaxes will be
-# initialized with the incoming data. As of 2023-12-30, this doesn't work
-# with autocast + torch.compile + FSDP. Enabling this option is nice for
-# testing, but this is not necessary for real training jobs.
-enable_amax_init = True
+from dataclasses import dataclass
 
-# If True, pre-forward and post-forward functions are run. As of 2023-12-30,
-# this doesn't work with autocast + torch.compile + FSDP. Enabling this
-# option is useful for safety, but not strictly necessary.
-enable_pre_and_post_forward = True
 
-# If True, then uses a tensor subclass for the fp8 linear module's weight that
-# implements pre/post-all-gather methods to do fp8 all-gather with FSDP2.
-# Only dynamic scaling is supported for now.
-enable_fsdp_fp8_all_gather = False
+@dataclass
+class Float8LinearConfig:
+
+    # If True, on the first iteration of Float8Linear the amaxes will be
+    # initialized with the incoming data. As of 2023-12-30, this doesn't work
+    # with autocast + torch.compile + FSDP. Enabling this option is nice for
+    # testing, but this is not necessary for real training jobs.
+    enable_amax_init: bool = True
+
+    # If True, pre-forward and post-forward functions are run. As of 2023-12-30,
+    # this doesn't work with autocast + torch.compile + FSDP. Enabling this
+    # option is useful for safety, but not strictly necessary.
+    enable_pre_and_post_forward: bool = True
+
+    # If True, then uses a tensor subclass for the fp8 linear module's weight that
+    # implements pre/post-all-gather methods to do fp8 all-gather with FSDP2.
+    # Only dynamic scaling is supported for now.
+    enable_fsdp_fp8_all_gather: bool = False
+
+    # If True, then prior to performing the fp8 scaled mamtmul we will pad the
+    # inner dimension of a (dim 1) and b (dim 2) with 0s. This is needed for matmuls
+    # _scaled_mm since it has the strong constraint that for M,N,K  N, K must be a multiple of 16.
+    # This can cause a memory spike however so we keep this off by default.
+    pad_inner_dim: bool = False
+
 
 # If True, use 'fnuz' float8 types for calculations.
 # Currently, ROCm only supports fnuz variants.
+# TODO(future PR): move this to Float8LinearConfig
 use_fnuz_dtype = False
-
-# If True, then prior to performing the fp8 scaled mamtmul we will pad the
-# inner dimension of a (dim 1) and b (dim 2) with 0s. This is needed for matmuls
-# _scaled_mm since it has the strong constraint that for M,N,K  N, K must be a multiple of 16.
-# This can cause a memory spike however so we keep this off by default.
-pad_inner_dim = False

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass
 
 @dataclass
 class Float8LinearConfig:
+    """
+    Configuration for converting a `torch.nn.Linear` module to float8
+    for training.
+    """
 
     # If True, on the first iteration of Float8Linear the amaxes will be
     # initialized with the incoming data. As of 2023-12-30, this doesn't work

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Optional
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from float8_experimental.config import Float8LinearConfig
 from float8_experimental.float8_linear import Float8Linear, TensorScalingType
 
 from float8_experimental.float8_utils import (
@@ -135,6 +136,7 @@ def swap_linear_with_float8_linear(
     scaling_type_input: TensorScalingType = TensorScalingType.DYNAMIC,
     scaling_type_weight: TensorScalingType = TensorScalingType.DYNAMIC,
     scaling_type_grad_output: TensorScalingType = TensorScalingType.DYNAMIC,
+    config: Float8LinearConfig = None,
 ) -> Optional[nn.Module]:
     """
     Swaps `torch.nn.Linear` in `module` with `Float8Linear`.
@@ -148,16 +150,20 @@ def swap_linear_with_float8_linear(
         scaling_type_input (TensorScalingType): scaling type for `input`
         scaling_type_weight (TensorScalingType): scaling type for `weight`
         scaling_type_grad_output (TensorScalingType): scaling type for `grad_output`
+        config (Float8LinearConfig): configuration for conversion to float8
 
     Returns:
      nn.Module: The modified module with swapped linear layers.
     """
+    if config is None:
+        config = Float8LinearConfig()
     from_float = lambda m: Float8Linear.from_float(
         m,
         emulate=emulate,
         scaling_type_input=scaling_type_input,
         scaling_type_weight=scaling_type_weight,
         scaling_type_grad_output=scaling_type_grad_output,
+        config=config,
     )
     return swap_linear_layers(
         module,

--- a/test/test_fsdp2/test_fsdp2_common.py
+++ b/test/test_fsdp2/test_fsdp2_common.py
@@ -86,15 +86,3 @@ def check_parity_bf16_mp(
             ):
                 param_bf16.detach().copy_(param_fp32)
         test_cls.assertEqual(losses[0], losses[1])
-
-
-@contextlib.contextmanager
-def set_enable_fsdp_fp8_all_gather(enable_fsdp_fp8_all_gather: bool):
-    prev = config.enable_fsdp_fp8_all_gather
-    dist.barrier()
-    config.enable_fsdp_fp8_all_gather = enable_fsdp_fp8_all_gather
-    try:
-        yield
-    finally:
-        dist.barrier()
-        config.enable_fsdp_fp8_all_gather = prev


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #325
* __->__ #324

Summary:

Adds a `Float8LinearConfig` to unify the user facing per-linear
configuration, and moves most of the previously global config options
there.

In future PRs (to keep PRs small), we will move emulation, scaling
and gemm configurations to also live here.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60176981](https://our.internmc.facebook.com/intern/diff/D60176981)