### PR TITLE
[bc-breaking] move tensor scaling configuration to Float8LinearConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,19 @@ m = Model(...)
 # gated with config.enable_amax_init and
 # config.enable_pre_and_post_forward are needed for 
 # autocast + compile + FSDP + float8 to work
-from float8_experimental import Float8LinearConfig
+from float8_experimental import Float8LinearConfig, TensorScalingType, Float8TensorCastConfig
 config = Float8LinearConfig(
     enable_amax_init = False,  # only needed for autocast + compile + FSDP +  float8 delayed
     enable_pre_and_post_forward, False  # only needed for autocast + compile + FSDP +  float8 delayed
+    cast_config_input=float8tensorcastconfig(scaling_type=TensorScalingType.DELAYED),
+    cast_config_weight=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
+    cast_config_grad_output=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
 )
 
 # convert all `torch.nn.Linear` modules to `Float8Linear`, specifying scaling
 # type
 swap_linear_with_float8_linear(
     m,
-    scaling_type_input=TensorScalingType.DELAYED,
-    scaling_type_weight=TensorScalingType.DELAYED,
-    scaling_type_grad_output=TensorScalingType.DELAYED,
     config=config,
 )
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ from float8_experimental import Float8LinearConfig, TensorScalingType, Float8Ten
 config = Float8LinearConfig(
     enable_amax_init = False,  # only needed for autocast + compile + FSDP +  float8 delayed
     enable_pre_and_post_forward, False  # only needed for autocast + compile + FSDP +  float8 delayed
-    cast_config_input=float8tensorcastconfig(scaling_type=TensorScalingType.DELAYED),
+    cast_config_input=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
     cast_config_weight=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
     cast_config_grad_output=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
 )

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -14,7 +14,11 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
 import torch.utils.benchmark as benchmark
-from float8_experimental.float8_linear import TensorScalingType
+from float8_experimental.config import (
+    Float8LinearConfig,
+    Float8TensorCastConfig,
+    TensorScalingType,
+)
 from float8_experimental.float8_linear_utils import (
     swap_linear_with_float8_linear,
     sync_float8_amax_and_scale_history,
@@ -27,6 +31,14 @@ torch.manual_seed(0)
 # TODO: Add more shapes for the benchmark
 B, M, K, N = 32, 1024, 1024, 1024
 lr = 0.01
+
+config = Float8LinearConfig(
+    cast_config_input=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
+    cast_config_weight=Float8TensorCastConfig(scaling_type=TensorScalingType.DELAYED),
+    cast_config_grad_output=Float8TensorCastConfig(
+        scaling_type=TensorScalingType.DELAYED
+    ),
+)
 
 
 def benchmark_torch_function_in_microseconds(
@@ -68,9 +80,7 @@ def get_model(K, N, is_fp8, base_dtype=torch.float32):
         swap_linear_with_float8_linear(
             m,
             emulate=False,
-            scaling_type_input=TensorScalingType.DELAYED,
-            scaling_type_weight=TensorScalingType.DELAYED,
-            scaling_type_grad_output=TensorScalingType.DELAYED,
+            config=config,
         )
     return m
 

--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -4,7 +4,11 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 # Lets define a few top level things here
-from float8_experimental.config import Float8LinearConfig
+from float8_experimental.config import (
+    Float8LinearConfig,
+    Float8TensorCastConfig,
+    TensorScalingType,
+)
 from float8_experimental.float8_linear import Float8Linear
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from float8_experimental.float8_tensor import (
@@ -21,7 +25,9 @@ add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole, LinearMMConfig])
 
 __all__ = [
     # configuration
+    "TensorScalingType",
     "Float8LinearConfig",
+    "Float8TensorCastConfig",
     # top level UX
     "swap_linear_with_float8_linear",
     # TODO(future): remove Float8Tensor and Float8Linear from public API

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -4,7 +4,29 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import enum
 from dataclasses import dataclass
+
+
+class TensorScalingType(enum.Enum):
+    DELAYED = "delayed"
+    DYNAMIC = "dynamic"
+
+    def short_str(self):
+        if self is TensorScalingType.DELAYED:
+            return "del"
+        else:
+            assert self is TensorScalingType.DYNAMIC
+            return "dyn"
+
+
+@dataclass(frozen=True)
+class Float8TensorCastConfig:
+    """
+    Configuration for casting a single tensor to float8
+    """
+
+    scaling_type: TensorScalingType = TensorScalingType.DYNAMIC
 
 
 @dataclass(frozen=True)
@@ -13,6 +35,17 @@ class Float8LinearConfig:
     Configuration for converting a `torch.nn.Linear` module to float8
     for training.
     """
+
+    #
+    # Per-tensor configuration for `input`, `weight`, `grad_output`
+    #
+    cast_config_input: Float8TensorCastConfig = Float8TensorCastConfig()
+    cast_config_weight: Float8TensorCastConfig = Float8TensorCastConfig()
+    cast_config_grad_output: Float8TensorCastConfig = Float8TensorCastConfig()
+
+    #
+    # Per-linear configuration
+    #
 
     # If True, on the first iteration of Float8Linear the amaxes will be
     # initialized with the incoming data. As of 2023-12-30, this doesn't work

--- a/float8_experimental/float8_tensor_parallel.py
+++ b/float8_experimental/float8_tensor_parallel.py
@@ -1,10 +1,10 @@
 import torch
 import torch.nn as nn
+from float8_experimental.config import TensorScalingType
 from float8_experimental.float8_dynamic_utils import (
     cast_to_float8_e4m3_dynamic,
     cast_to_float8_e5m2_dynamic_bw,
 )
-from float8_experimental.float8_linear import TensorScalingType
 from float8_experimental.float8_tensor import GemmInputRole
 from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import DeviceMesh

--- a/float8_experimental/fsdp_utils.py
+++ b/float8_experimental/fsdp_utils.py
@@ -33,7 +33,8 @@ def precompute_float8_dynamic_scale_for_fsdp(module: nn.Module) -> None:
         optim.step()
         precompute_float8_dynamic_scale_for_fsdp(model)
     """
-    from float8_experimental.float8_linear import Float8Linear, TensorScalingType
+    from float8_experimental.config import TensorScalingType
+    from float8_experimental.float8_linear import Float8Linear
     from torch.distributed._tensor import DTensor
 
     if any(

--- a/test/test_inference_flows.py
+++ b/test/test_inference_flows.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from float8_experimental.float8_linear import TensorScalingType
+from float8_experimental.config import TensorScalingType
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
 from float8_experimental.float8_tensor import Float8Tensor
 from float8_experimental.float8_utils import compute_error
@@ -191,12 +191,7 @@ class TestFP8TrainToFP8LinearInference:
         # Initialize FP8 model
         fp8_mlp = FeedForward().to("cuda", dtype=torch.float32)
         fp8_mlp.reset_parameters()
-        swap_linear_with_float8_linear(
-            fp8_mlp,
-            scaling_type_input=TensorScalingType.DYNAMIC,
-            scaling_type_weight=TensorScalingType.DYNAMIC,
-            scaling_type_grad_output=TensorScalingType.DYNAMIC,
-        )
+        swap_linear_with_float8_linear(fp8_mlp)
 
         # Train the model
         self.train(fp8_mlp, dtype)
@@ -215,12 +210,7 @@ class TestFP8TrainToFP8LinearInference:
         # Later on you load the model, will be w/ Float8Linear on meta device
         with torch.device("meta"):
             new_fp8_mlp = FeedForward().to(dtype=dtype)
-            swap_linear_with_float8_linear(
-                new_fp8_mlp,
-                scaling_type_input=TensorScalingType.DYNAMIC,
-                scaling_type_weight=TensorScalingType.DYNAMIC,
-                scaling_type_grad_output=TensorScalingType.DYNAMIC,
-            )
+            swap_linear_with_float8_linear(new_fp8_mlp)
 
         # Load the actual data
         new_fp8_mlp.load_state_dict(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #325
* #324

Summary:

Moves the fields configuring per-tensor scaling options to
`Float8LinearConfig`, to set us up for upcoming new configurations such
as other scaling granularities, and simplify configuraiton in general.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60176980](https://our.internmc.facebook.com/intern/diff/D60176980)