### PR TITLE
[bc-breaking] move `emulate` flag to `Float8LinearConfig`

### DIFF
--- a/benchmarks/bench_linear_float8.py
+++ b/benchmarks/bench_linear_float8.py
@@ -147,7 +147,6 @@ def main(
 
         linear_float8 = Float8Linear.from_float(
             copy.deepcopy(linear_ref),
-            emulate=False,
             config=config,
         )
         scaling_repr = linear_float8.scaling_repr()

--- a/benchmarks/bench_multi_gpu.py
+++ b/benchmarks/bench_multi_gpu.py
@@ -79,7 +79,6 @@ def get_model(K, N, is_fp8, base_dtype=torch.float32):
     if is_fp8:
         swap_linear_with_float8_linear(
             m,
-            emulate=False,
             config=config,
         )
     return m

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -69,6 +69,9 @@ class Float8LinearConfig:
     # This can cause a memory spike however so we keep this off by default.
     pad_inner_dim: bool = False
 
+    # If True, emulation is used instead of hardware accelerated gemm
+    emulate: bool = False
+
 
 # If True, use 'fnuz' float8 types for calculations.
 # Currently, ROCm only supports fnuz variants.

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -166,8 +166,8 @@ class Float8Linear(torch.nn.Linear):
         )
         # Amax scales should always be kept as float32.
         self.always_float32_buffers = set()
-        emulate = kwargs.pop("emulate", False)
         config = kwargs.pop("config")
+        emulate = config.emulate
         super().__init__(*args, **kwargs)
 
         # Defines the scaling behavior of input, weight, grad_output
@@ -434,7 +434,6 @@ class Float8Linear(torch.nn.Linear):
     def from_float(
         cls,
         mod,
-        emulate: bool = False,
         config: Optional[Float8LinearConfig] = None,
     ):
         """
@@ -442,7 +441,6 @@ class Float8Linear(torch.nn.Linear):
 
         Args:
             mod (torch.nn.Linear): nn.Linear to convert
-            emulate (bool): whether to emulate fp8 matmul logic in float32
             config (Optional[Float8LinearConfig]): configuration for conversion to float8
         """
         if config is None:
@@ -452,7 +450,6 @@ class Float8Linear(torch.nn.Linear):
                 mod.in_features,
                 mod.out_features,
                 bias=False,
-                emulate=emulate,
                 config=config,
             )
         new_mod.weight = mod.weight

--- a/float8_experimental/float8_linear_utils.py
+++ b/float8_experimental/float8_linear_utils.py
@@ -127,7 +127,6 @@ def swap_linear_layers(
 def swap_linear_with_float8_linear(
     module: nn.Module,
     *,
-    emulate: bool = False,
     module_filter_fn: Optional[Callable[[str, nn.Module], bool]] = None,
     config: Float8LinearConfig = None,
 ) -> Optional[nn.Module]:
@@ -136,7 +135,6 @@ def swap_linear_with_float8_linear(
 
     Args:
         module: Module to modify.
-        emulate: If True, emulation is used instead of hardware accelerated gemm
         module_filter_fn: If specified, only the `torch.nn.Linear` subclasses that
             that pass the filter function will be swapped. The inputs to the
             filter function are the FQN and module instance.
@@ -149,7 +147,6 @@ def swap_linear_with_float8_linear(
         config = Float8LinearConfig()
     from_float = lambda m: Float8Linear.from_float(
         m,
-        emulate=emulate,
         config=config,
     )
     return swap_linear_layers(

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -13,7 +13,7 @@ import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from float8_experimental.config import TensorScalingType
+from float8_experimental import Float8LinearConfig
 
 from float8_experimental.float8_dynamic_utils import NoopFwToFloat8E5M2Bw
 from float8_experimental.float8_linear_utils import swap_linear_with_float8_linear
@@ -184,14 +184,15 @@ def _test_fp8_mlp_tensor_parallelism_base(
     # For now, only supports dynamic scaling of `x` and `dL_dY`.
     # TODO(future): add support for float8 all-gather with delayed scaling
     # for activations and gradients.
+    config = Float8LinearConfig(emulate=True)
 
     toy_model = ToyModel().to(device)
-    toy_model_fp8 = swap_linear_with_float8_linear(toy_model, emulate=True)
+    toy_model_fp8 = swap_linear_with_float8_linear(toy_model, config=config)
 
     tp_model = copy.deepcopy(toy_model)
-    tp_model = swap_linear_with_float8_linear(tp_model, emulate=True)
+    tp_model = swap_linear_with_float8_linear(tp_model, config=config)
     sp_model = copy.deepcopy(toy_model)
-    sp_model = swap_linear_with_float8_linear(sp_model, emulate=True)
+    sp_model = swap_linear_with_float8_linear(sp_model, config=config)
 
     # vanilla TP
     tp_model = parallelize_module(
@@ -222,7 +223,7 @@ def _test_fp8_mlp_tensor_parallelism_base(
 
     # PrepareFloat8ModuleInput with specific submodule fqn
     sp_model2 = copy.deepcopy(toy_model)
-    sp_model2 = swap_linear_with_float8_linear(sp_model2, emulate=True)
+    sp_model2 = swap_linear_with_float8_linear(sp_model2, config=config)
 
     sp_model2 = parallelize_module(
         sp_model2,

--- a/test/test_fsdp.py
+++ b/test/test_fsdp.py
@@ -84,13 +84,14 @@ def fsdp_main(rank, world_size, args):
     )
     config = Float8LinearConfig(
         cast_config_weight=Float8TensorCastConfig(scaling_type=scaling_type_weight),
+        # TODO(future): delete this arg as it's always False
+        emulate=False,
     )
 
     # Note: we only iterate over `scaling_type_weight` because FSDP only interacts
     # with weights.
     swap_linear_with_float8_linear(
         model_fp8,
-        emulate=False,
         config=config,
     )
 

--- a/test/test_fsdp_compile.py
+++ b/test/test_fsdp_compile.py
@@ -66,6 +66,7 @@ def get_model(K, N, is_fp8, emulate, base_dtype=torch.float32):
         cast_config_grad_output=Float8TensorCastConfig(
             scaling_type=TensorScalingType.DELAYED
         ),
+        emulate=emulate,
     )
 
     m = nn.Sequential(
@@ -74,7 +75,6 @@ def get_model(K, N, is_fp8, emulate, base_dtype=torch.float32):
     )
     swap_linear_with_float8_linear(
         m,
-        emulate=emulate,
         config=config,
     )
     return m

--- a/test/test_numerics_integration.py
+++ b/test/test_numerics_integration.py
@@ -122,7 +122,6 @@ class TestFloat8NumericsIntegrationTest:
         )
         swap_linear_with_float8_linear(
             model_fp8,
-            emulate=False,
             config=config,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #330
* #329
* #328
* __->__ #327

Summary:

Cleaning up the UX further.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60195667](https://our.internmc.facebook.com/intern/diff/D60195667)