### PR TITLE
[bc-breaking] rename `config.enable_fsdp_fp8_all_gather` to use `float8`

### DIFF
--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -58,10 +58,9 @@ class Float8LinearConfig:
     # option is useful for safety, but not strictly necessary.
     enable_pre_and_post_forward: bool = True
 
-    # If True, then uses a tensor subclass for the fp8 linear module's weight that
-    # implements pre/post-all-gather methods to do fp8 all-gather with FSDP2.
-    # Only dynamic scaling is supported for now.
-    enable_fsdp_fp8_all_gather: bool = False
+    # If True, then uses a tensor subclass for the float8 linear module's weight that
+    # implements pre/post-all-gather methods to do float8 all-gather with FSDP2.
+    enable_fsdp_float8_all_gather: bool = False
 
     # If True, then prior to performing the fp8 scaled mamtmul we will pad the
     # inner dimension of a (dim 1) and b (dim 2) with 0s. This is needed for matmuls

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -467,7 +467,7 @@ class Float8Linear(torch.nn.Linear):
         # 1. weight needs to be on the correct device to create the buffers
         # 2. buffers need to be already created for the delayed scaling version
         #    of the weight wrapper to be initialized
-        if config.enable_fsdp_fp8_all_gather:
+        if config.enable_fsdp_float8_all_gather:
             if config.cast_config_weight.scaling_type is TensorScalingType.DYNAMIC:
                 new_mod.weight = torch.nn.Parameter(
                     WeightWithDynamicFloat8CastTensor(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #336
* #337
* #335
* #334
* #333
* __->__ #332

Summary:

old: `enable_fsdp_fp8_all_gather`
new: `enable_fsdp_float8_all_gather`

this is to match the `float8` naming elsewhere

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60252072](https://our.internmc.facebook.com/intern/diff/D60252072)