### PR TITLE
add per-gemm config to `Float8LinearConfig`

### DIFF
--- a/float8_experimental/__init__.py
+++ b/float8_experimental/__init__.py
@@ -6,6 +6,7 @@
 # Lets define a few top level things here
 from float8_experimental.config import (
     DelayedScalingConfig,
+    Float8GemmConfig,
     Float8LinearConfig,
     Float8TensorCastConfig,
     TensorScalingType,
@@ -33,6 +34,7 @@ __all__ = [
     # configuration
     "DelayedScalingConfig",
     "TensorScalingType",
+    "Float8GemmConfig",
     "Float8LinearConfig",
     "Float8TensorCastConfig",
     # top level UX

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -84,7 +84,7 @@ class Float8LinearConfig:
     #
     gemm_config_output: Float8GemmConfig = Float8GemmConfig(use_fast_accum=True)
     gemm_config_grad_input: Float8GemmConfig = Float8GemmConfig()
-    gemm_config_grad_weight: Float8GemmConfig = Float8GemmConfig(use_fast_accum=True)
+    gemm_config_grad_weight: Float8GemmConfig = Float8GemmConfig()
 
     #
     # Per-linear configuration

--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -54,6 +54,17 @@ class DelayedScalingConfig:
 
 
 @dataclass(frozen=True)
+class Float8GemmConfig:
+    """
+    Configuration for a float8 gemm.
+    """
+
+    # If True, fast accumulation in lower precision is used.
+    # Note: this flag is currently a no-op if emulation is turned on.
+    use_fast_accum: bool = False
+
+
+@dataclass(frozen=True)
 class Float8LinearConfig:
     """
     Configuration for converting a `torch.nn.Linear` module to float8
@@ -66,6 +77,14 @@ class Float8LinearConfig:
     cast_config_input: Float8TensorCastConfig = Float8TensorCastConfig()
     cast_config_weight: Float8TensorCastConfig = Float8TensorCastConfig()
     cast_config_grad_output: Float8TensorCastConfig = Float8TensorCastConfig()
+
+    #
+    # Per-gemm configuration for gemms calculating `output`, `grad_input` and
+    # `grad_weight`
+    #
+    gemm_config_output: Float8GemmConfig = Float8GemmConfig(use_fast_accum=True)
+    gemm_config_grad_input: Float8GemmConfig = Float8GemmConfig()
+    gemm_config_grad_weight: Float8GemmConfig = Float8GemmConfig(use_fast_accum=True)
 
     #
     # Per-linear configuration

--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -168,24 +168,28 @@ class Float8Linear(torch.nn.Linear):
 
         self.create_buffers()
 
-        # TODO(future): user level configuration of gemms
         self.linear_mm_config = LinearMMConfig(
-            # input
+            # output
             ScaledMMConfig(
                 emulate,
-                True if not emulate else False,
+                self.config.gemm_config_output.use_fast_accum,
                 False,
                 self.config.pad_inner_dim,
             ),
-            # weight
+            # grad_input
             ScaledMMConfig(
                 emulate,
-                True if not emulate else False,
+                self.config.gemm_config_grad_input.use_fast_accum,
                 False,
                 self.config.pad_inner_dim,
             ),
-            # grad_output
-            ScaledMMConfig(emulate, False, False, self.config.pad_inner_dim),
+            # grad_weight
+            ScaledMMConfig(
+                emulate,
+                self.config.gemm_config_grad_weight.use_fast_accum,
+                False,
+                self.config.pad_inner_dim,
+            ),
         )
 
         # Note: is_amax_initialized is not a buffer to avoid data dependent


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #336
* #337
* #335
* __->__ #334
* #333
* #332

Summary:

Previously the per-gemm configuration had to be hardcoded in library
code. This PR exposes it to the top-level UX by adding a
`Float8GemmConfig` field to `Float8LinearConfig`.

Note that today the only supported configuration option is
`use_fast_accum`.  In the future, configuring output_dtype
and whether to keep a gemm in higher precision would go here.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60252069](https://our.internmc.facebook.com/intern/diff/D60252069)