### PR TITLE
rename all variables to use input/weight/grad_output notation

### DIFF
--- a/float8_experimental/float8_dynamic_utils.py
+++ b/float8_experimental/float8_dynamic_utils.py
@@ -42,7 +42,7 @@ class NoopFwToFloat8E5M2Bw(torch.autograd.Function):
             gradY_scale,
             e5m2_dtype,
             linear_mm_config=ctx.linear_mm_config,
-            gemm_input_role=GemmInputRole.DL_DY,
+            gemm_input_role=GemmInputRole.GRAD_OUTPUT,
         )
         return fp8_tensor, None
 
@@ -51,7 +51,7 @@ def cast_to_float8_e4m3_dynamic(
     inpt_tensor: torch.Tensor,
     linear_mm_config: LinearMMConfig,
     reduce_amax: bool = False,
-    gemm_input_role: GemmInputRole = GemmInputRole.X,
+    gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
 ) -> Float8Tensor:
     if tensor_already_casted_to_fp8(inpt_tensor):
         return inpt_tensor

--- a/float8_experimental/float8_tensor_parallel.py
+++ b/float8_experimental/float8_tensor_parallel.py
@@ -48,7 +48,7 @@ class Float8ColwiseParallel(ColwiseParallel):
         input_tensor = cast_to_float8_e4m3_dynamic(
             input_tensor,
             mod.linear_mm_config,
-            gemm_input_role=GemmInputRole.X,
+            gemm_input_role=GemmInputRole.INPUT,
         )  # DTensor(Float8Tensor)
 
         # transform the input layouts to the desired layouts of ColwiseParallel
@@ -101,7 +101,7 @@ class Float8RowwiseParallel(RowwiseParallel):
         input_tensor = cast_to_float8_e4m3_dynamic(
             input_tensor,
             mod.linear_mm_config,
-            gemm_input_role=GemmInputRole.X,
+            gemm_input_role=GemmInputRole.INPUT,
         )  # DTensor(Float8Tensor)
 
         if input_layouts != desired_input_layouts:
@@ -199,7 +199,7 @@ class PrepareFloat8ModuleInput(PrepareModuleInput):
             dt_inp = cast_to_float8_e4m3_dynamic(
                 dt_inp,
                 self.linear_mm_config,
-                gemm_input_role=GemmInputRole.X,
+                gemm_input_role=GemmInputRole.INPUT,
             )  # DTensor(Float8Tensor)
             if desired_layout is not None and input_layout != desired_layout:
                 dt_inp = dt_inp.redistribute(placements=(desired_layout,))

--- a/float8_experimental/fsdp_utils.py
+++ b/float8_experimental/fsdp_utils.py
@@ -171,14 +171,14 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
                 self._precomputed_scale,
                 torch.float8_e4m3fn,
                 linear_mm_config=self._linear_mm_config,
-                gemm_input_role=GemmInputRole.W,
+                gemm_input_role=GemmInputRole.WEIGHT,
             )
         else:
             float8_tensor = cast_to_float8_e4m3_dynamic(
                 self._tensor,
                 self._linear_mm_config,
                 reduce_amax=True,
-                gemm_input_role=GemmInputRole.W,
+                gemm_input_role=GemmInputRole.WEIGHT,
             )
         return (float8_tensor._data,), (float8_tensor._scale,)
 
@@ -201,7 +201,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
             scale,
             param_dtype,
             self._linear_mm_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         ), (data,)
 
 
@@ -364,7 +364,7 @@ class WeightWithDelayedFloat8CastTensor(torch.Tensor):
             e4m3_dtype,
             self._amax_buffer,
             self._linear_mm_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         )
         return (float8_tensor._data,), (float8_tensor._scale,)
 
@@ -387,5 +387,5 @@ class WeightWithDelayedFloat8CastTensor(torch.Tensor):
             scale,
             param_dtype,
             self._linear_mm_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         ), (data,)

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -132,7 +132,7 @@ class Float8InferenceLinear(torch.nn.Linear):
             scale,
             dtype,
             self.linear_mm_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         )
         self.weight = nn.Parameter(quantized_weight)
         self.weight.requires_grad = False
@@ -205,7 +205,7 @@ def cast_to_float8_e4m3_inference(
         scale,
         e4m3_dtype,
         linear_mm_config=linear_mm_config,
-        gemm_input_role=GemmInputRole.X,
+        gemm_input_role=GemmInputRole.INPUT,
     )
 
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -395,7 +395,7 @@ class TestFloat8Linear:
             config=config,
         )
         s = m.__repr__()
-        assert "x:dyn,w:del,dldy:dyn" in s
+        assert "i:dyn,w:del,go:dyn" in s
 
 
 class TestScaledMM:
@@ -464,18 +464,18 @@ class TestScaledMM:
             x_scale,
             fp8_dtype,
             linear_mm_config=linear_config_a,
-            gemm_input_role=GemmInputRole.X,
+            gemm_input_role=GemmInputRole.INPUT,
         )
         b = Float8Tensor.to_float8(
             x_fp32,
             x_scale,
             fp8_dtype,
             linear_mm_config=linear_config_b,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         )
         with pytest.raises(
             AssertionError,
-            match="linear_mm_config.y mismatch",
+            match="linear_mm_config.output mismatch",
         ):
             a @ b
 
@@ -499,10 +499,10 @@ class TestScaledMM:
         b_scale = tensor_to_scale(b, input_dtype).float()
 
         a_fp8 = Float8Tensor.to_float8(
-            a, a_scale, input_dtype, gemm_input_role=GemmInputRole.X
+            a, a_scale, input_dtype, gemm_input_role=GemmInputRole.INPUT
         )
         b_fp8 = Float8Tensor.to_float8(
-            b, b_scale, input_dtype, gemm_input_role=GemmInputRole.W
+            b, b_scale, input_dtype, gemm_input_role=GemmInputRole.WEIGHT
         )
 
         with pytest.raises(
@@ -523,14 +523,14 @@ class TestScaledMM:
             a_scale,
             input_dtype,
             linear_mm_config=pad_config,
-            gemm_input_role=GemmInputRole.X,
+            gemm_input_role=GemmInputRole.INPUT,
         )
         b_fp8 = Float8Tensor.to_float8(
             b,
             b_scale,
             input_dtype,
             linear_mm_config=pad_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         )
         out_padded = a_fp8 @ b_fp8
         out_padded.to(compare_type)
@@ -546,14 +546,14 @@ class TestScaledMM:
             a_scale,
             input_dtype,
             linear_mm_config=emulated_config,
-            gemm_input_role=GemmInputRole.X,
+            gemm_input_role=GemmInputRole.INPUT,
         )
         b_fp8 = Float8Tensor.to_float8(
             b,
             b_scale,
             input_dtype,
             linear_mm_config=emulated_config,
-            gemm_input_role=GemmInputRole.W,
+            gemm_input_role=GemmInputRole.WEIGHT,
         )
         out_emualted = a_fp8 @ b_fp8
         out_emualted.to(compare_type)
@@ -606,8 +606,8 @@ class TestFloat8LinearUtils(unittest.TestCase):
             config = Float8LinearConfig(emulate=emulate)
             module = convert_to_float8_training(module, config=config)
             self.assertIsInstance(module, Float8Linear)
-            self.assertEqual(module.linear_mm_config.y.emulate, emulate)
-            self.assertEqual(module.linear_mm_config.y.emulate, emulate)
+            self.assertEqual(module.linear_mm_config.output.emulate, emulate)
+            self.assertEqual(module.linear_mm_config.output.emulate, emulate)
 
     def test_swap_root_linear_with_children_raises(self):
         for emulate in [True, False]:

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -256,9 +256,9 @@ class TestGraphBreaks(DynamoTestCase):
             type(y_compiled._orig_dtype)
         )
         assert isinstance(
-            y_compiled._linear_mm_config.y.emulate, bool
+            y_compiled._linear_mm_config.output.emulate, bool
         ), "Float8Tensor._emulate should be a bool but got {}".format(
-            type(y_compiled._linear_mm_config.y.emulate)
+            type(y_compiled._linear_mm_config.output.emulate)
         )
 
 

--- a/test/test_dtensor.py
+++ b/test/test_dtensor.py
@@ -87,10 +87,10 @@ def test_scaled_mm(mesh: DeviceMesh, size=16):
         y_scale = tensor_to_scale(y_fp32, fp8_dtype).float()
 
         x_fp8 = Float8Tensor.to_float8(
-            x_fp32, x_scale, fp8_dtype, gemm_input_role=GemmInputRole.X
+            x_fp32, x_scale, fp8_dtype, gemm_input_role=GemmInputRole.INPUT
         )
         y_fp8 = Float8Tensor.to_float8(
-            y_fp32, y_scale, fp8_dtype, gemm_input_role=GemmInputRole.W
+            y_fp32, y_scale, fp8_dtype, gemm_input_role=GemmInputRole.WEIGHT
         )
 
         dist_x_fp8 = DTensor.from_local(x_fp8, mesh, [lhs_placement], run_check=False)
@@ -164,10 +164,13 @@ def test_dtensor_fp8_autograd(mesh: DeviceMesh, size=16):
     dist_target = distribute_tensor(target, mesh, [Shard(0)])
 
     dist_x_fp8 = Float8Tensor.to_float8(
-        dist_x_fp32, dist_x_scale, fp8_dtype, gemm_input_role=GemmInputRole.X
+        dist_x_fp32, dist_x_scale, fp8_dtype, gemm_input_role=GemmInputRole.INPUT
     )
     dist_weight_fp8 = Float8Tensor.to_float8(
-        dist_wight_fp32, dist_weight_scale, fp8_dtype, gemm_input_role=GemmInputRole.W
+        dist_wight_fp32,
+        dist_weight_scale,
+        fp8_dtype,
+        gemm_input_role=GemmInputRole.WEIGHT,
     )
 
     out = torch.nn.functional.linear(dist_x_fp8, dist_weight_fp8)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #336
* #337
* __->__ #335
* #334
* #333
* #332

Summary:

In https://github.com/pytorch-labs/float8_experimental/pull/323 we
changed the user facing variable notation from `x/w/dL_dY` to
`input/weight/grad_output`.

This PR follows up by changing most of the internal variables to also match
the new notation, to reduce confusion.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60252071](https://our.internmc.facebook.com/intern/diff/D60252071)