### PR TITLE
[4/x] clean up casting: ToFloat8ConstrFunc -> hp_tensor_and_scale_to_float8

### DIFF
--- a/benchmarks/bench_padding.py
+++ b/benchmarks/bench_padding.py
@@ -6,9 +6,9 @@ import fire
 import torch
 from float8_experimental.float8_tensor import (
     GemmInputRole,
+    hp_tensor_and_scale_to_float8,
     LinearMMConfig,
     ScaledMMConfig,
-    ToFloat8ConstrFunc,
 )
 from float8_experimental.float8_utils import pad_tensor_for_matmul
 from tabulate import tabulate
@@ -58,14 +58,14 @@ def do_fp8_matmul(A, B, fp8_dtype, out_dtype):
     a_config = LinearMMConfig(a_config, a_config, a_config)
     b_config = LinearMMConfig(b_config, b_config, b_config)
 
-    a_fp8 = ToFloat8ConstrFunc.apply(
+    a_fp8 = hp_tensor_and_scale_to_float8(
         A,
         scale_a,
         fp8_dtype,
         a_config,
         GemmInputRole.INPUT,
     )
-    b_fp8 = ToFloat8ConstrFunc.apply(
+    b_fp8 = hp_tensor_and_scale_to_float8(
         B,
         scale_b,
         fp8_dtype,

--- a/float8_experimental/float8_scaling_utils.py
+++ b/float8_experimental/float8_scaling_utils.py
@@ -15,10 +15,10 @@ import torch
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
+    hp_tensor_and_scale_to_float8,
     LinearMMConfig,
     ScaledMMConfig,
     tensor_already_casted_to_fp8,
-    ToFloat8ConstrFunc,
 )
 
 from float8_experimental.float8_utils import (
@@ -39,7 +39,7 @@ def cast_to_float8_e4m3_dynamic(
     if tensor_already_casted_to_fp8(inpt_tensor):
         return inpt_tensor
     scale = tensor_to_scale(inpt_tensor, e4m3_dtype, reduce_amax)
-    return ToFloat8ConstrFunc.apply(
+    return hp_tensor_and_scale_to_float8(
         inpt_tensor,
         scale,
         e4m3_dtype,
@@ -58,7 +58,7 @@ def cast_to_float8_delayed(
     gemm_input_role: Optional[GemmInputRole] = GemmInputRole.INPUT,
 ):
     amax_buffer.fill_(tensor_to_amax(tensor))
-    return ToFloat8ConstrFunc.apply(
+    return hp_tensor_and_scale_to_float8(
         tensor,
         scale,
         float8_dtype,
@@ -145,7 +145,7 @@ class NoopFwToFloat8E5M2BwDelayed(torch.autograd.Function):
 
         fp8_amax_grad_output.fill_(tensor_to_amax(go))
 
-        res = ToFloat8ConstrFunc.apply(
+        res = hp_tensor_and_scale_to_float8(
             go,
             fp8_scale_grad_output,
             e5m2_dtype,
@@ -177,7 +177,7 @@ class NoopFwToFloat8E5M2BwDynamic(torch.autograd.Function):
         if tensor_already_casted_to_fp8(gradY):
             return gradY, None
         gradY_scale = tensor_to_scale(gradY, e5m2_dtype)
-        fp8_tensor = ToFloat8ConstrFunc.apply(
+        fp8_tensor = hp_tensor_and_scale_to_float8(
             gradY,
             gradY_scale,
             e5m2_dtype,

--- a/float8_experimental/fsdp_utils.py
+++ b/float8_experimental/fsdp_utils.py
@@ -18,8 +18,8 @@ from float8_experimental.float8_scaling_utils import (
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
+    hp_tensor_and_scale_to_float8,
     LinearMMConfig,
-    ToFloat8ConstrFunc,
 )
 
 from float8_experimental.float8_utils import e4m3_dtype, EPS
@@ -167,7 +167,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
 
     def fsdp_pre_all_gather(self, mesh):
         if self._precomputed_scale is not None:
-            float8_tensor = ToFloat8ConstrFunc.apply(
+            float8_tensor = hp_tensor_and_scale_to_float8(
                 self._tensor,
                 self._precomputed_scale,
                 torch.float8_e4m3fn,

--- a/float8_experimental/inference.py
+++ b/float8_experimental/inference.py
@@ -19,10 +19,10 @@ from float8_experimental.float8_linear_utils import swap_linear_layers
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
+    hp_tensor_and_scale_to_float8,
     LinearMMConfig,
     ScaledMMConfig,
     tensor_already_casted_to_fp8,
-    ToFloat8ConstrFunc,
 )
 from float8_experimental.float8_utils import e4m3_dtype, tensor_to_scale
 
@@ -127,7 +127,7 @@ class Float8InferenceLinear(torch.nn.Linear):
             self.weight, Float8Tensor
         ), "Weight has already been quantized, cannot quantize again."
         scale = tensor_to_scale(self.weight, dtype)
-        quantized_weight = ToFloat8ConstrFunc.apply(
+        quantized_weight = hp_tensor_and_scale_to_float8(
             self.weight,
             scale,
             dtype,
@@ -200,7 +200,7 @@ def cast_to_float8_e4m3_inference(
         if static_quantization_scale is not None
         else tensor_to_scale(inpt_tensor, e4m3_dtype, reduce_amax)
     )
-    return ToFloat8ConstrFunc.apply(
+    return hp_tensor_and_scale_to_float8(
         inpt_tensor,
         scale,
         e4m3_dtype,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #351
* #350
* #349
* __->__ #348
* #347
* #346
* #345
* #344

Summary:

Moves `ToFloat8ConstrFunc` to private, and creates
`hp_tensor_and_scale_to_float8` as the official wrapper
which clearly describes what this function is doing.

A future PR will rename the scaling-aware functions to match this
naming.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60310240](https://our.internmc.facebook.com/intern/diff/D60310240)