### PR TITLE
[6/x] clean up casting: rename delayed and dynamic casting functions

### DIFF
--- a/float8_experimental/float8_linear.py
+++ b/float8_experimental/float8_linear.py
@@ -18,8 +18,8 @@ from float8_experimental.config import Float8LinearConfig, ScalingType
 
 from float8_experimental.float8_scaling_utils import (
     _maybe_initialize_amaxes_scales_for_float8_cast,
-    cast_to_float8_delayed,
-    cast_to_float8_dynamic,
+    hp_tensor_to_float8_delayed,
+    hp_tensor_to_float8_dynamic,
     NoopFwToFloat8E5M2BwDelayed,
     NoopFwToFloat8E5M2BwDynamic,
 )
@@ -260,7 +260,7 @@ class Float8Linear(torch.nn.Linear):
                 is_amax_initialized,
                 reduce_amax=True,
             )
-            input_fp8 = cast_to_float8_delayed(
+            input_fp8 = hp_tensor_to_float8_delayed(
                 input,
                 self.fp8_scale_input,
                 e4m3_dtype,
@@ -270,7 +270,9 @@ class Float8Linear(torch.nn.Linear):
             )
         else:
             assert self.scaling_type_input is ScalingType.DYNAMIC
-            input_fp8 = cast_to_float8_dynamic(input, e4m3_dtype, self.linear_mm_config)
+            input_fp8 = hp_tensor_to_float8_dynamic(
+                input, e4m3_dtype, self.linear_mm_config
+            )
         return input_fp8
 
     def cast_weight_to_float8(
@@ -292,7 +294,7 @@ class Float8Linear(torch.nn.Linear):
                     reduce_amax=False,
                 )
 
-                weight_fp8 = cast_to_float8_delayed(
+                weight_fp8 = hp_tensor_to_float8_delayed(
                     weight,
                     self.fp8_scale_weight,
                     e4m3_dtype,
@@ -305,7 +307,7 @@ class Float8Linear(torch.nn.Linear):
             if isinstance(self.weight, Float8Tensor):  # cast by FSDP
                 weight_fp8 = self.weight
             else:
-                weight_fp8 = cast_to_float8_dynamic(
+                weight_fp8 = hp_tensor_to_float8_dynamic(
                     self.weight,
                     e4m3_dtype,
                     self.linear_mm_config,

--- a/float8_experimental/float8_tensor_parallel.py
+++ b/float8_experimental/float8_tensor_parallel.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 from float8_experimental.config import ScalingType
 from float8_experimental.float8_scaling_utils import (
-    cast_to_float8_dynamic,
+    hp_tensor_to_float8_dynamic,
     NoopFwToFloat8E5M2BwDynamic,
 )
 from float8_experimental.float8_tensor import GemmInputRole
@@ -46,7 +46,7 @@ class Float8ColwiseParallel(ColwiseParallel):
                 input_tensor, device_mesh, input_layouts, run_check=False
             )
 
-        input_tensor = cast_to_float8_dynamic(
+        input_tensor = hp_tensor_to_float8_dynamic(
             input_tensor,
             e4m3_dtype,
             mod.linear_mm_config,
@@ -100,7 +100,7 @@ class Float8RowwiseParallel(RowwiseParallel):
                 input_tensor, device_mesh, input_layouts, run_check=False
             )
 
-        input_tensor = cast_to_float8_dynamic(
+        input_tensor = hp_tensor_to_float8_dynamic(
             input_tensor,
             e4m3_dtype,
             mod.linear_mm_config,
@@ -199,7 +199,7 @@ class PrepareFloat8ModuleInput(PrepareModuleInput):
                     input, mesh, (input_layout,), run_check=False
                 )
 
-            dt_inp = cast_to_float8_dynamic(
+            dt_inp = hp_tensor_to_float8_dynamic(
                 dt_inp,
                 e4m3_dtype,
                 self.linear_mm_config,

--- a/float8_experimental/fsdp_utils.py
+++ b/float8_experimental/fsdp_utils.py
@@ -11,8 +11,8 @@ import torch
 import torch.nn as nn
 import torch.utils._pytree as pytree
 from float8_experimental.float8_scaling_utils import (
-    cast_to_float8_delayed,
-    cast_to_float8_dynamic,
+    hp_tensor_to_float8_delayed,
+    hp_tensor_to_float8_dynamic,
 )
 
 from float8_experimental.float8_tensor import (
@@ -175,7 +175,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
                 GemmInputRole.WEIGHT,
             )
         else:
-            float8_tensor = cast_to_float8_dynamic(
+            float8_tensor = hp_tensor_to_float8_dynamic(
                 self._tensor,
                 e4m3_dtype,
                 self._linear_mm_config,
@@ -355,7 +355,7 @@ class WeightWithDelayedFloat8CastTensor(torch.Tensor):
             )
             self.is_amax_initialized = True
 
-        float8_tensor = cast_to_float8_delayed(
+        float8_tensor = hp_tensor_to_float8_delayed(
             self._tensor,
             self._scale_buffer,
             e4m3_dtype,

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -20,7 +20,7 @@ from float8_experimental.float8_linear_utils import (
     get_float8_layers,
     sync_float8_amax_and_scale_history,
 )
-from float8_experimental.float8_scaling_utils import cast_to_float8_delayed
+from float8_experimental.float8_scaling_utils import hp_tensor_to_float8_delayed
 from float8_experimental.float8_tensor import LinearMMConfig
 from float8_experimental.float8_utils import e4m3_dtype
 
@@ -179,7 +179,7 @@ class TestGraphBreaks(DynamoTestCase):
             self.graph_break = graph_break
 
         def forward(self, x):
-            x_fp8 = cast_to_float8_delayed(
+            x_fp8 = hp_tensor_to_float8_delayed(
                 x,
                 self.fp8_scale_x,
                 e4m3_dtype,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #351
* __->__ #350
* #349
* #348
* #347
* #346
* #345
* #344

Summary:

Renames the delayed and dynamic casting functions to
`hp_tensor_to_float8_delayed` and `hp_tensor_to_float8_dynamic`
to clarify what they are doing and how they are different from
`hp_tensor_and_scale_to_float8`.

Test Plan:

```
./test/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D60310241](https://our.internmc.facebook.com/intern/diff/D60310241)