### PR TITLE
[wip] add axiswise granularity to Float8Tensor

### DIFF
--- a/float8_experimental/config.py
+++ b/float8_experimental/config.py
@@ -21,6 +21,18 @@ class ScalingType(enum.Enum):
             return "dyn"
 
 
+class ScalingGranularity(enum.Enum):
+    """
+    Defines the granularity of scaling strategies for casting to float8
+    """
+
+    # A single scaling factor for the entire tensor
+    TENSORWISE = "tensorwise"
+    # Scaling factors computed along one axis of the tensor, reducing it to
+    # size 1.
+    AXISWISE = "axiswise"
+
+
 @dataclass(frozen=True)
 class CastConfig:
     """

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -19,6 +19,15 @@ _c10d_functional = torch.ops._c10d_functional
 FLOAT8_OPS_TABLE: Dict[Any, Any] = {}
 
 
+def _assert_tensorwise_scale(aten_op, scale):
+    assert (
+        # TODO(future PR): figure out why tensorwise scaling can have
+        # both rank 0 and rank 1
+        len(scale.shape)
+        in (0, 1)
+    ), f"{aten_op} with axiswise scaling is not supported yet"
+
+
 def implements(aten_ops):
     """Register aten ops to the float8 op table"""
 
@@ -34,16 +43,15 @@ def implements(aten_ops):
     [
         aten.view.default,
         aten._unsafe_view.default,
-        aten.t.default,
         aten.as_strided.default,
         aten.clone.default,
         aten.detach.default,
         aten.slice.Tensor,
-        aten.transpose.int,
         aten.fill_.Scalar,
     ]
 )
 def float8_desugar_op(aten_op, args, kwargs=None):
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
     return Float8Tensor(
         new_data,
@@ -54,8 +62,27 @@ def float8_desugar_op(aten_op, args, kwargs=None):
     )
 
 
+@implements(
+    [
+        aten.t.default,
+        aten.transpose.int,
+    ]
+)
+def float8_desugar_data_and_scale(aten_op, args, kwargs=None):
+    new_data = aten_op(args[0]._data, *args[1:], **kwargs)
+    new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
+    return Float8Tensor(
+        new_data,
+        new_scale,
+        args[0]._orig_dtype,
+        args[0]._linear_mm_config,
+        args[0]._gemm_input_role,
+    )
+
+
 @implements([aten.split.Tensor])
 def float8_split(aten_op, args, kwargs=None):
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     new_data_tensors = aten_op(args[0]._data, *args[1:], **kwargs)
 
     def make_float8(data):
@@ -101,6 +128,7 @@ def float8_cat(aten_op, args, kwargs=None):
         assert (
             chunk._gemm_input_role is gemm_input_role
         ), "Expecting all chunks to have the same gemm_input_role as a result of a split"
+        _assert_tensorwise_scale(aten_op, chunk._scale)
         chunk_data.append(chunk._data.view(torch.uint8))
 
     new_data = aten_op(chunk_data, *args[1:], **kwargs)
@@ -117,6 +145,7 @@ def float8_cast_up_op(aten_op, args, kwargs=None):
     "addmm" -> out
     "hp_gradBias" <-"sum" <- "identity" <- gradOut <- "hp_gradOut"
     """
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
 
     def unwrap(x):
         if isinstance(x, Float8Tensor):
@@ -229,6 +258,7 @@ def float8_addmm(aten_op, args, kwargs=None):
 
 @implements([aten.is_same_size.default])
 def float8_is_same_size(aten_op, args, kwargs=None):
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     return args[0].shape == args[1].shape
 
 
@@ -238,6 +268,7 @@ def autocast_to_copy(aten_op, args, kwargs=None):
     when the input is a Float8Tensor, presenting as a fp32
     tensor.
     """
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     assert isinstance(args[0], Float8Tensor)
     assert (
         len(kwargs) == 1 and "dtype" in kwargs
@@ -265,6 +296,7 @@ def allgather_fp8(aten_op, args, kwargs=None):
     """
     override funcol with FP8 handling
     """
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     fp8_input = args[0]
     assert isinstance(
         fp8_input, Float8Tensor
@@ -284,6 +316,7 @@ def allgather_fp8(aten_op, args, kwargs=None):
 
 @implements([c10d_functional.wait_tensor.default, _c10d_functional.wait_tensor.default])
 def wait_tensor_fp8(aten_op, args, kwargs=None):
+    _assert_tensorwise_scale(aten_op, args[0]._scale)
     fp8_input = args[0]
     assert isinstance(fp8_input, Float8Tensor)
 
@@ -304,6 +337,7 @@ def index_put_fp8(aten_op, args, kwargs=None):
     fp8_values = args[2]
     assert isinstance(fp8_self, Float8Tensor)
     assert isinstance(fp8_values, Float8Tensor)
+    _assert_tensorwise_scale(fp8_self, args[0]._scale)
     assert fp8_self._scale == fp8_values._scale
     assert fp8_self.dtype == fp8_values.dtype
     assert fp8_self._orig_dtype == fp8_values._orig_dtype
@@ -334,8 +368,10 @@ def copy_fp8(aten_op, args, kwargs=None):
 
     if not isinstance(self, Float8Tensor) and isinstance(src, Float8Tensor):
         src_hp = src.to_original_precision()
+        _assert_tensorwise_scale(aten_op, src._scale)
         return aten_op(self, src_hp, *args[2:], **kwargs)
     elif isinstance(self, Float8Tensor) and isinstance(src, Float8Tensor):
+        _assert_tensorwise_scale(aten_op, src._scale)
         assert (
             self._orig_dtype == src._orig_dtype
         ), "Expecting both Float8Tensors to be of the same dtype"

--- a/float8_experimental/float8_ops.py
+++ b/float8_experimental/float8_ops.py
@@ -41,7 +41,6 @@ def implements(aten_ops):
 
 @implements(
     [
-        # aten.view.default,
         aten._unsafe_view.default,
         aten.as_strided.default,
         aten.clone.default,
@@ -79,19 +78,40 @@ def float8_desugar_data_and_scale(aten_op, args, kwargs=None):
         args[0]._gemm_input_role,
     )
 
+
 @implements([aten.view.default])
 def float8_view(aten_op, args, kwargs=None):
     if len(args[0]._scale.shape) < 2:
         # tensorwise scaling
-        return float8_desugar_op(aten_op, *args, **kwargs)
-    print('args', args)
-    print('kwargs', kwargs)
-    tensor, new_shape = args[0], args[1]
+        return float8_desugar_op(aten_op, args, kwargs)
 
-    # for now, only support reshaping to [-1, *dims] or [*dims, -1]
-    if len(new_shape) >= 2 and (new_shape[0] == -1 or new_shape[-1] == -1):
-        return float8_desugar_data_and_scale(aten_op, *args, **kwargs)
-    raise AssertionError(f"{aten_op} with axiswise scaling and shape {new_shape} is not supported yet.")
+    t, new_shape = args[0], args[1]
+    # for now, only support reshaping to [-1, dim] or [dim, -1]
+    if len(new_shape) == 2:
+        if new_shape == [t.shape[0], -1] and t._scale.shape[0] == 1:
+            new_data = aten_op(t._data, new_shape, **kwargs)
+            new_scale = aten_op(t._scale, [1, -1], **kwargs)
+            return Float8Tensor(
+                new_data,
+                new_scale,
+                t._orig_dtype,
+                t._linear_mm_config,
+                t._gemm_input_role,
+            )
+        elif new_shape == [-1, t.shape[-1]] and t._scale.shape[-1] == 1:
+            new_data = aten_op(t._data, new_shape, **kwargs)
+            new_scale = aten_op(t._scale, [-1, 1], **kwargs)
+            return Float8Tensor(
+                new_data,
+                new_scale,
+                t._orig_dtype,
+                t._linear_mm_config,
+                t._gemm_input_role,
+            )
+    raise AssertionError(
+        f"{aten_op} with axiswise scaling and t.shape {t.shape} t._scale.shape {t._scale.shape} new_shape {new_shape} is not supported yet."
+    )
+
 
 @implements([aten.split.Tensor])
 def float8_split(aten_op, args, kwargs=None):

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -38,7 +38,6 @@ def addmm_float8_unwrapped(
     """
     a_inverse_scale = a_scale.reciprocal()
     b_inverse_scale = b_scale.reciprocal()
-
     if output_dtype == torch.float32 and bias is not None:
         # Bias is not supported by _scaled_mm when output is fp32
         output = torch._scaled_mm(

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -38,6 +38,14 @@ def addmm_float8_unwrapped(
     """
     a_inverse_scale = a_scale.reciprocal()
     b_inverse_scale = b_scale.reciprocal()
+
+    # TODO: should we change torch._scaled_mm?
+    # torch._scaled_mm expects rowwise scaled scales to be of rank 1, not rank
+    # 2.  Translate to this format.
+    # TODO: audit if we need to make this more generic for various shapes.
+    a_inverse_scale = a_inverse_scale.squeeze()
+    b_inverse_scale = b_inverse_scale.squeeze()
+
     if output_dtype == torch.float32 and bias is not None:
         # Bias is not supported by _scaled_mm when output is fp32
         output = torch._scaled_mm(

--- a/float8_experimental/float8_python_api.py
+++ b/float8_experimental/float8_python_api.py
@@ -39,13 +39,6 @@ def addmm_float8_unwrapped(
     a_inverse_scale = a_scale.reciprocal()
     b_inverse_scale = b_scale.reciprocal()
 
-    # TODO: should we change torch._scaled_mm?
-    # torch._scaled_mm expects rowwise scaled scales to be of rank 1, not rank
-    # 2.  Translate to this format.
-    # TODO: audit if we need to make this more generic for various shapes.
-    a_inverse_scale = a_inverse_scale.squeeze()
-    b_inverse_scale = b_inverse_scale.squeeze()
-
     if output_dtype == torch.float32 and bias is not None:
         # Bias is not supported by _scaled_mm when output is fp32
         output = torch._scaled_mm(

--- a/float8_experimental/float8_scaling_utils.py
+++ b/float8_experimental/float8_scaling_utils.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 import torch
 
+from float8_experimental.config import ScalingGranularity
+
 from float8_experimental.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
@@ -36,6 +38,8 @@ def hp_tensor_to_float8_dynamic(
     linear_mm_config: LinearMMConfig,
     reduce_amax: bool = False,
     gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
+    scaling_granularity: ScalingGranularity = ScalingGranularity.TENSORWISE,
+    axiswise_dim: Optional[int] = None,
 ) -> Float8Tensor:
     """
     Given a high precision tensor `hp_tensor`,
@@ -49,10 +53,18 @@ def hp_tensor_to_float8_dynamic(
         reduce_amax: whether to reduce the max(abs(hp_tensor)) value across distributed ranks
         gemm_input_role: Defines the role of this tensor (input, weight or grad_output) in
           the 3 fwd/bwd gemms of linear
+        scaling_granularity: Defines the scaling granularity
+        axiswise_dim: if axiswise granularity is used, defines the dim to scale across
     """
     if tensor_already_casted_to_fp8(hp_tensor):
         return hp_tensor
-    scale = tensor_to_scale(hp_tensor, float8_dtype, reduce_amax)
+    scale = tensor_to_scale(
+        hp_tensor,
+        float8_dtype,
+        reduce_amax,
+        scaling_granularity,
+        axiswise_dim,
+    )
     return hp_tensor_and_scale_to_float8(
         hp_tensor,
         scale,

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -115,9 +115,9 @@ def tensor_to_amax(
 
         # convert from axiswise_dim (dim to keep) to
         # dim as the input to the `torch.amax` function (tuple of dims to reduce)
-        dim_to_reduce = tuple(d for d in range(len(x.shape)) if d != axiswise_dim)
+        # dim_to_reduce = tuple(d for d in range(len(x.shape)) if d != axiswise_dim)
 
-        amax = torch.amax(torch.abs(x), dim=dim_to_reduce, keepdim=True)
+        amax = torch.amax(torch.abs(x), dim=axiswise_dim, keepdim=True)
 
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will

--- a/float8_experimental/float8_utils.py
+++ b/float8_experimental/float8_utils.py
@@ -112,11 +112,6 @@ def tensor_to_amax(
     else:
         assert scaling_granularity is ScalingGranularity.AXISWISE, "unsupported"
         assert axiswise_dim is not None, "unsupported"
-
-        # convert from axiswise_dim (dim to keep) to
-        # dim as the input to the `torch.amax` function (tuple of dims to reduce)
-        # dim_to_reduce = tuple(d for d in range(len(x.shape)) if d != axiswise_dim)
-
         amax = torch.amax(torch.abs(x), dim=axiswise_dim, keepdim=True)
 
     # If the user asked for distributed reduction, do it.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #351
* #350
* #349
* #348
* #347
* #346
* #345
* #344

Summary:

This PR adds the axiswise scaling granularity to `Float8Tensor` and
ensures that basic ops like transpose and `torch._scaled_mm` work as
expected.

A future PR will add integration with `Float8Linear`.

Test Plan:

TODO

Reviewers:

Subscribers:

Tasks:

Tags: